### PR TITLE
Implement help command

### DIFF
--- a/src/main/java/seedu/modtrek/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/AddCommand.java
@@ -18,20 +18,20 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds module to the ModTrek. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds module to ModTrek.\n"
             + "Parameters: "
             + PREFIX_CODE + "MODULE CODE "
             + PREFIX_CREDIT + "MODULE CREDITS "
             + PREFIX_SEMYEAR + "SEMESTER-YEAR "
             + PREFIX_GRADE + "GRADE "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG...]\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_CODE + "CS1101S "
-            + PREFIX_CREDIT + "4 "
-            + PREFIX_SEMYEAR + "Y1S1 "
-            + PREFIX_GRADE + "A "
-            + PREFIX_TAG + "University Level Requirement "
-            + PREFIX_TAG + "Computer Science Foundation";
+            + PREFIX_CODE + " CS1101S "
+            + PREFIX_CREDIT + " 4 "
+            + PREFIX_SEMYEAR + " Y1S1 "
+            + PREFIX_GRADE + " A "
+            + PREFIX_TAG + " University Level Requirement "
+            + PREFIX_TAG + " Computer Science Foundation";
 
     public static final String MESSAGE_SUCCESS = "New module added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This module has already been added.Try using edit instead.";

--- a/src/main/java/seedu/modtrek/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/DeleteCommand.java
@@ -26,7 +26,7 @@ public class DeleteCommand extends Command {
      * The constant MESSAGE_USAGE.
      */
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the module identified by the module code\n"
+            + ": Deletes the module identified by the module code.\n"
             + "Parameters: {all} /m MODULE CODE\n"
             + "Example: " + COMMAND_WORD + " /m CS1101S";
 

--- a/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
@@ -36,7 +36,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_CREDIT + "CREDITS] "
             + "[" + PREFIX_SEMYEAR + "SEMESTER-YEAR] "
             + "[" + PREFIX_GRADE + "GRADE] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG...]\n"
             + "Example: " + COMMAND_WORD + " CS2106 "
             + PREFIX_CREDIT + " 4 "
             + PREFIX_SEMYEAR + " Y2S2";

--- a/src/main/java/seedu/modtrek/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/ExitCommand.java
@@ -11,6 +11,10 @@ public class ExitCommand extends Command {
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting ModTrek as requested ...";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits ModTrek.\n"
+            + "Parameters: NIL\n"
+            + "Example: " + COMMAND_WORD;
+
     @Override
     public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);

--- a/src/main/java/seedu/modtrek/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/FindCommand.java
@@ -14,8 +14,8 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds module with the specified module code \n"
-            + "Parameters: MODULE CODE \n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds module with the specified module code.\n"
+            + "Parameters: MODULE CODE\n"
             + "Example: " + COMMAND_WORD + " CS1101S";
 
     private final ModuleCodePredicate predicate;

--- a/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
@@ -41,4 +41,11 @@ public class HelpCommand extends Command {
         }
         return new CommandResult(selectedMessage);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof HelpCommand // instanceof handles nulls
+                && selectedMessage.equals(((HelpCommand) other).selectedMessage)); // state check
+    }
 }

--- a/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
@@ -1,6 +1,9 @@
 package seedu.modtrek.logic.commands;
 
 import seedu.modtrek.model.Model;
+import seedu.modtrek.model.module.Code;
+
+import java.util.Set;
 
 /**
  * Format full help instructions for every command for display.
@@ -9,13 +12,36 @@ public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the usage of command(s).\n"
+            + "Parameters: COMMAND (Optional)\n"
+            + "Example: " + COMMAND_WORD + " add";
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String SHOWING_HELP_MESSAGE = "Here is a summary of all our commands:\n\n";
+
+    public static final String SHOWING_ALL_MESSAGE_USAGE = SHOWING_HELP_MESSAGE + AddCommand.MESSAGE_USAGE
+            + "\n\n" + EditCommand.MESSAGE_USAGE
+            + "\n\n" + DeleteCommand.MESSAGE_USAGE
+            + "\n\n" + TagCommand.MESSAGE_USAGE
+            + "\n\n" + ListCommand.MESSAGE_USAGE
+            + "\n\n" + FindCommand.MESSAGE_USAGE
+            + "\n\n" + ExitCommand.MESSAGE_USAGE;
+
+    private final String selectedMessage;
+
+    /**
+     * Instantiates a new Help command.
+     *
+     * @param message Message usage for the specified command
+     */
+    public HelpCommand(String message) {
+        this.selectedMessage = message;
+    }
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        if (selectedMessage.isEmpty()) {
+            return new CommandResult(SHOWING_ALL_MESSAGE_USAGE);
+        }
+        return new CommandResult(selectedMessage);
     }
 }

--- a/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
@@ -1,9 +1,6 @@
 package seedu.modtrek.logic.commands;
 
 import seedu.modtrek.model.Model;
-import seedu.modtrek.model.module.Code;
-
-import java.util.Set;
 
 /**
  * Format full help instructions for every command for display.

--- a/src/main/java/seedu/modtrek/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/ListCommand.java
@@ -14,6 +14,10 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all modules";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all modules sorted by Year/Sem.\n"
+            + "Parameters: NIL\n"
+            + "Example: " + COMMAND_WORD;
+
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/modtrek/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/TagCommand.java
@@ -30,8 +30,8 @@ public class TagCommand extends Command {
      * The constant MESSAGE_USAGE.
      */
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds tags to the module identified "
-            + "Parameters: CODE (module code) include/remove"
+            + ": Adds tags to the module identified.\n"
+            + "Parameters: CODE (module code) include/remove\n"
             + "Example: " + COMMAND_WORD + " CS1101S " + "include "
             + "/t UNIVERSITY LEVEL REQUIREMENTS";
 

--- a/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.modtrek.logic.parser;
+
+import seedu.modtrek.logic.commands.AddCommand;
+import seedu.modtrek.logic.commands.EditCommand;
+import seedu.modtrek.logic.commands.DeleteCommand;
+import seedu.modtrek.logic.commands.HelpCommand;
+import seedu.modtrek.logic.commands.TagCommand;
+import seedu.modtrek.logic.commands.ListCommand;
+import seedu.modtrek.logic.commands.FindCommand;
+import seedu.modtrek.logic.commands.ExitCommand;
+import seedu.modtrek.logic.parser.exceptions.ParseException;
+
+import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new HelpCommand object
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the HelpCommand
+     * and returns a HelpCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public HelpCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return new HelpCommand("");
+        } else {
+            switch (trimmedArgs.toUpperCase()) {
+            case "ADD":
+                return new HelpCommand(AddCommand.MESSAGE_USAGE);
+            case "EDIT":
+                return new HelpCommand(EditCommand.MESSAGE_USAGE);
+            case "DELETE":
+                return new HelpCommand(DeleteCommand.MESSAGE_USAGE);
+            case "TAG":
+                return new HelpCommand(TagCommand.MESSAGE_USAGE);
+            case "LIST":
+                return new HelpCommand(ListCommand.MESSAGE_USAGE);
+            case "FIND":
+                return new HelpCommand(FindCommand.MESSAGE_USAGE);
+            case "EXIT":
+                return new HelpCommand(ExitCommand.MESSAGE_USAGE);
+            default:
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
@@ -1,16 +1,16 @@
 package seedu.modtrek.logic.parser;
 
-import seedu.modtrek.logic.commands.AddCommand;
-import seedu.modtrek.logic.commands.EditCommand;
-import seedu.modtrek.logic.commands.DeleteCommand;
-import seedu.modtrek.logic.commands.HelpCommand;
-import seedu.modtrek.logic.commands.TagCommand;
-import seedu.modtrek.logic.commands.ListCommand;
-import seedu.modtrek.logic.commands.FindCommand;
-import seedu.modtrek.logic.commands.ExitCommand;
-import seedu.modtrek.logic.parser.exceptions.ParseException;
-
 import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.modtrek.logic.commands.AddCommand;
+import seedu.modtrek.logic.commands.DeleteCommand;
+import seedu.modtrek.logic.commands.EditCommand;
+import seedu.modtrek.logic.commands.ExitCommand;
+import seedu.modtrek.logic.commands.FindCommand;
+import seedu.modtrek.logic.commands.HelpCommand;
+import seedu.modtrek.logic.commands.ListCommand;
+import seedu.modtrek.logic.commands.TagCommand;
+import seedu.modtrek.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new HelpCommand object

--- a/src/main/java/seedu/modtrek/logic/parser/ModTrekParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/ModTrekParser.java
@@ -67,7 +67,7 @@ public class ModTrekParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         case TagCommand.COMMAND_WORD:
             return new TagCommandParser().parse(arguments);

--- a/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.modtrek.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Locale;
@@ -31,23 +30,20 @@ public class TagCommandParser implements Parser<TagCommand> {
         Code code;
         boolean isInclude;
 
-        try {
-            String preamble = argMultimap.getPreamble();
-            String[] preambleParts = preamble.split(" ");
-            code = ParserUtil.parseCode(preambleParts[0]);
-            if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("include")) {
-                isInclude = true;
-            } else if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("remove")) {
-                isInclude = false;
-            } else {
-                throw new ParseException("Did not specify include/remove tags");
-            }
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE), pe);
+        String preamble = argMultimap.getPreamble();
+        String[] preambleParts = preamble.split(" ");
+        code = ParserUtil.parseCode(preambleParts[0]);
+        if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("include")) {
+            isInclude = true;
+        } else if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("remove")) {
+            isInclude = false;
+        } else {
+            throw new ParseException("Did not specify whether to include or remove tags");
         }
-
         Set<Tag> tag = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
+        if (tag.isEmpty()) {
+            throw new ParseException("Did not specify prefix /t");
+        }
         return new TagCommand(code, isInclude, tag);
     }
 }

--- a/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
@@ -35,9 +35,9 @@ public class TagCommandParser implements Parser<TagCommand> {
             String preamble = argMultimap.getPreamble();
             String[] preambleParts = preamble.split(" ");
             code = ParserUtil.parseCode(preambleParts[0]);
-            if (preambleParts[1].toLowerCase(Locale.ROOT).equals("include")) {
+            if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("include")) {
                 isInclude = true;
-            } else if (preambleParts[1].toLowerCase(Locale.ROOT).equals("remove")) {
+            } else if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("remove")) {
                 isInclude = false;
             } else {
                 throw new ParseException("Did not specify include/remove tags");

--- a/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
@@ -15,6 +15,6 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
@@ -19,8 +19,44 @@ public class HelpCommandTest {
     }
 
     @Test
-    public void execute_helpValidArgs_success() {
+    public void execute_helpAdd_success() {
         CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE);
         assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpEdit_success() {
+        CommandResult expectedCommandResult = new CommandResult(EditCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(EditCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpDelete_success() {
+        CommandResult expectedCommandResult = new CommandResult(DeleteCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(DeleteCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpTag_success() {
+        CommandResult expectedCommandResult = new CommandResult(TagCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(TagCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpList_success() {
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(ListCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpFind_success() {
+        CommandResult expectedCommandResult = new CommandResult(FindCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(FindCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpExit_success() {
+        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(ExitCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.modtrek.logic.commands;
 
 import static seedu.modtrek.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.modtrek.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
+import static seedu.modtrek.logic.commands.HelpCommand.SHOWING_ALL_MESSAGE_USAGE;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,8 +13,14 @@ public class HelpCommandTest {
     private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    public void execute_helpNoArgs_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_ALL_MESSAGE_USAGE);
         assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpValidArgs_success() {
+        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE);
+        assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.modtrek.logic.parser;
+
+import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.modtrek.logic.commands.AddCommand;
+import seedu.modtrek.logic.commands.HelpCommand;
+
+public class HelpCommandParserTest {
+    private HelpCommandParser parser = new HelpCommandParser();
+
+    @Test
+    public void parse_helpNoArgs_success() {
+        assertParseSuccess(parser, "", new HelpCommand(""));
+    }
+
+    @Test
+    public void parse_helpValidArgs_success() {
+        assertParseSuccess(parser, "add", new HelpCommand(AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpInvalidArgs_failure() {
+        assertParseFailure(parser, "wrong",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
@@ -7,7 +7,13 @@ import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.AddCommand;
+import seedu.modtrek.logic.commands.DeleteCommand;
+import seedu.modtrek.logic.commands.EditCommand;
+import seedu.modtrek.logic.commands.ExitCommand;
+import seedu.modtrek.logic.commands.FindCommand;
 import seedu.modtrek.logic.commands.HelpCommand;
+import seedu.modtrek.logic.commands.ListCommand;
+import seedu.modtrek.logic.commands.TagCommand;
 
 public class HelpCommandParserTest {
     private HelpCommandParser parser = new HelpCommandParser();
@@ -18,8 +24,38 @@ public class HelpCommandParserTest {
     }
 
     @Test
-    public void parse_helpValidArgs_success() {
+    public void parse_helpAdd_success() {
         assertParseSuccess(parser, "add", new HelpCommand(AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpEdit_success() {
+        assertParseSuccess(parser, "edit", new HelpCommand(EditCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpDelete_success() {
+        assertParseSuccess(parser, "delete", new HelpCommand(DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpTag_success() {
+        assertParseSuccess(parser, "tag", new HelpCommand(TagCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpList_success() {
+        assertParseSuccess(parser, "list", new HelpCommand(ListCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpFind_success() {
+        assertParseSuccess(parser, "find", new HelpCommand(FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_helpExit_success() {
+        assertParseSuccess(parser, "exit", new HelpCommand(ExitCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
@@ -81,7 +81,7 @@ public class ModTrekParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " add") instanceof HelpCommand);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/TagCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.modtrek.logic.parser;
 
-import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_CODE_CS1101S;
+import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_CS1101S;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -13,43 +13,63 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.TagCommand;
+import seedu.modtrek.model.module.Code;
 import seedu.modtrek.model.tag.Tag;
 
 class TagCommandParserTest {
 
-    private static final String TAG_EMPTY = " " + PREFIX_TAG;
-
-    private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE);
-
-    private TagCommandParser parser = new TagCommandParser();
+    private final TagCommandParser parser = new TagCommandParser();
 
     @Test
-    public void parse_missingparts_failure() {
+    public void parse_missingParts_failure() {
         // no module specified
-        assertParseFailure(parser, PREFIX_TAG + "Computer Science Foundation", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_TAG + "Computer Science Foundation", Code.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, VALID_CODE_CS1101S + "Computer Science Foundation", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_CODE_CS1101S + "Computer Science Foundation",
+                Code.MESSAGE_CONSTRAINTS);
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, VALID_CODE_CS1101S + "/i " + "Computer Science Foundation",
-                MESSAGE_INVALID_FORMAT);
+                Code.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, VALID_CODE_CS1101S + " include " + INVALID_TAG_DESC,
-                Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, VALID_CODE_CS1101S + " include" + INVALID_TAG_DESC,
+                Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, VALID_CODE_CS1101S + " remove" + INVALID_TAG_DESC,
+                Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_missingPrefix_failure() {
+        assertParseFailure(parser, VALID_CODE_CS1101S + " include",
+                "Did not specify prefix /t");
+        assertParseFailure(parser, VALID_CODE_CS1101S + " remove",
+                "Did not specify prefix /t");
+    }
+
+    @Test
+    public void parse_missingIncludeRemove_failure() {
+        assertParseFailure(parser, VALID_CODE_CS1101S,
+                "Did not specify whether to include or remove tags");
+        assertParseFailure(parser, VALID_CODE_CS1101S,
+                "Did not specify whether to include or remove tags");
     }
 
     @Test
     public void parse_success() {
-        assertParseSuccess(parser, VALID_CODE_CS1101S + " include ", new TagCommand(CS1101S.getCode(),
-                true, new HashSet<>()));
+        HashSet<Tag> tags = new HashSet<>();
+        Tag newTag = new Tag("Computer Science Foundation");
+        tags.add(newTag);
+        assertParseSuccess(parser, VALID_CODE_CS1101S + " include " + PREFIX_TAG + " " + VALID_TAG_CS1101S,
+                new TagCommand(CS1101S.getCode(), true, tags));
+        assertParseSuccess(parser, VALID_CODE_CS1101S + " remove " + PREFIX_TAG + " " + VALID_TAG_CS1101S,
+                new TagCommand(CS1101S.getCode(), false, tags));
     }
 
 }


### PR DESCRIPTION
- Implemented the help command for:
`help` - Displays the entire list of commands usage
`help [COMMAND]` - Displays the command usage for a specific command (i.e. add)

- Wrote some test cases for HelpCommand and HelpCommandParser.

closes #56 