### PR TITLE
Correctly display relevant screen on GUI for different commands

### DIFF
--- a/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
@@ -37,9 +37,9 @@ public class HelpCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         if (selectedMessage.isEmpty()) {
-            return new CommandResult(SHOWING_ALL_MESSAGE_USAGE);
+            return new CommandResult(SHOWING_ALL_MESSAGE_USAGE, false, false, false, false);
         }
-        return new CommandResult(selectedMessage);
+        return new CommandResult(selectedMessage, false, false, false, false);
     }
 
     @Override

--- a/src/main/java/seedu/modtrek/model/DegreeProgressionData.java
+++ b/src/main/java/seedu/modtrek/model/DegreeProgressionData.java
@@ -3,6 +3,7 @@ package seedu.modtrek.model;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import seedu.modtrek.model.module.Module;
 import seedu.modtrek.model.module.UniqueModuleList;
@@ -76,6 +77,21 @@ public class DegreeProgressionData {
                 .append(String.format("> Planned:   %1$d\n", plannedCredit))
                 .append(String.format("> Total:     %1$d\n", TOTALCREDIT));
         return details.toString();
+    }
+
+    public Map<String, Integer> getRequirementsPercentage() {
+        Map<String, Integer> result = completedRequirementCredits
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                    float percent = ((float) entry.getValue() / ValidTag.getTotalCredit(entry.getKey())) * 100;
+                    return percent > 100 ? 100 : (int) percent;
+                }));
+        return result;
+    }
+
+    public int getOverallPercentage() {
+        return  (int) ((float) completedCredit / TOTALCREDIT * 100);
     }
 
     private void computeModule(Module module) {

--- a/src/main/java/seedu/modtrek/model/DegreeProgressionData.java
+++ b/src/main/java/seedu/modtrek/model/DegreeProgressionData.java
@@ -91,7 +91,7 @@ public class DegreeProgressionData {
     }
 
     public int getOverallPercentage() {
-        return  (int) ((float) completedCredit / TOTALCREDIT * 100);
+        return (int) ((float) completedCredit / TOTALCREDIT * 100);
     }
 
     private void computeModule(Module module) {

--- a/src/main/java/seedu/modtrek/model/tag/Tag.java
+++ b/src/main/java/seedu/modtrek/model/tag/Tag.java
@@ -58,7 +58,6 @@ public class Tag {
      * Format state as text for viewing.
      */
     public String toString() {
-        return tagName.replace("_", " ");
+        return ValidTag.getLongForm(tagName).toString().replace("_", " ");
     }
-
 }

--- a/src/main/java/seedu/modtrek/model/tag/ValidTag.java
+++ b/src/main/java/seedu/modtrek/model/tag/ValidTag.java
@@ -40,7 +40,7 @@ public enum ValidTag {
     /**
      * Retrieves short form version of the requirement.
      *
-     * @param tagName
+     * @param tagName the long-form version of the requirement
      * @return ValidTag as the short-form
      */
     public static ValidTag getShortForm(String tagName) {
@@ -59,6 +59,33 @@ public enum ValidTag {
             return MS;
         case UNRESTRICTED_ELECTIVES:
             return UE;
+        default:
+            return tag;
+        }
+    }
+
+    /**
+     * Retrieves long form version of the requirement.
+     *
+     * @param tagName the short-form version of the requirement
+     * @return ValidTag as the long-form
+     */
+    public static ValidTag getLongForm(String tagName) {
+        tagName = tagName.replace(" ", "_").toUpperCase();
+        ValidTag tag = ValidTag.valueOf(tagName);
+        switch (tag) {
+        case ULR:
+            return UNIVERSITY_LEVEL_REQUIREMENTS;
+        case CSF:
+            return COMPUTER_SCIENCE_FOUNDATION;
+        case CSBD:
+            return COMPUTER_SCIENCE_BREADTH_AND_DEPTH;
+        case ITP:
+            return IT_PROFESSIONALISM;
+        case MS:
+            return MATHEMATICS_AND_SCIENCES;
+        case UE:
+            return UNRESTRICTED_ELECTIVES;
         default:
             return tag;
         }

--- a/src/main/java/seedu/modtrek/ui/MainWindow.java
+++ b/src/main/java/seedu/modtrek/ui/MainWindow.java
@@ -39,8 +39,6 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private VBox cliSectionPlaceholder;
 
-    /* add more... */
-
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
@@ -63,7 +61,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        resultsSection = new ResultsSection(logic.getDegreeProgression(), logic.getFilteredModuleList());
+        resultsSection = new ResultsSection(logic);
         resultsSectionPlaceholder.getChildren().add(resultsSection.getRoot());
 
         cliSection = new CliSection(this::executeCommand);
@@ -109,8 +107,15 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
 
-            // To refresh the graphics section to display updated list of modules
-            resultsSection.displayAllModules(logic.getFilteredModuleList());
+            if (commandResult.isDisplayProgress) {
+                resultsSection.displayProgress(logic.getDegreeProgression());
+            } else if (commandResult.isDisplayAllModules) {
+                resultsSection.displayAllModules(logic.getDegreeProgression().getModuleList());
+            } else if (commandResult.isDisplayFilteredModules) {
+                resultsSection.displayFindModules(logic.getFilteredModuleList());
+            } else {
+                // do nothing for `exit` and `help` commands
+            }
 
             if (commandResult.isExit()) {
                 handleExit();

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
@@ -22,9 +22,6 @@ public class ModuleCard extends UiPart<Region> {
     private Label moduleCardCode;
 
     @FXML
-    private HBox moduleCardInfo;
-
-    @FXML
     private Label moduleCardYearSem;
 
     @FXML

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
@@ -73,6 +73,7 @@ public class ModuleCard extends UiPart<Region> {
         for (Tag tag : module.getTags()) {
             String tagNameShort = ValidTag.getShortForm(tag.tagName).toString();
             String tagNameLong = tag.toString();
+            System.out.println(tagNameLong);
             String color = ValidTag.getColor(tag.tagName);
             addTag(tagNameShort, tagNameLong, color);
         }

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
@@ -4,7 +4,6 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.util.Duration;
 import seedu.modtrek.model.module.Module;
@@ -73,7 +72,6 @@ public class ModuleCard extends UiPart<Region> {
         for (Tag tag : module.getTags()) {
             String tagNameShort = ValidTag.getShortForm(tag.tagName).toString();
             String tagNameLong = tag.toString();
-            System.out.println(tagNameLong);
             String color = ValidTag.getColor(tag.tagName);
             addTag(tagNameShort, tagNameLong, color);
         }

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
@@ -44,6 +44,10 @@ public class ModuleCard extends UiPart<Region> {
     public ModuleCard(Module module) {
         super(FXML);
 
+        if (!module.isComplete()) {
+            addIncompleteStyles();
+        }
+
         fillCard(module);
     }
 
@@ -92,5 +96,16 @@ public class ModuleCard extends UiPart<Region> {
         Tooltip tagToolTip = new Tooltip(tagNameLong);
         Tooltip.install(tag, tagToolTip);
         tagToolTip.setShowDelay(Duration.seconds(0.05));
+    }
+
+    /**
+     * Adds CSS styles to ModuleCard for the case where module is incomplete.
+     */
+    private void addIncompleteStyles() {
+        this.getRoot().getStyleClass().add("module-card-incomplete");
+
+        Tooltip incompleteWarning = new Tooltip("This module is incomplete!");
+        Tooltip.install(this.getRoot(), incompleteWarning);
+        incompleteWarning.setShowDelay(Duration.seconds(0.05));
     }
 }

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleCard.java
@@ -4,6 +4,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.util.Duration;
 import seedu.modtrek.model.module.Module;
@@ -19,6 +20,12 @@ public class ModuleCard extends UiPart<Region> {
 
     @FXML
     private Label moduleCardCode;
+
+    @FXML
+    private HBox moduleCardInfo;
+
+    @FXML
+    private Label moduleCardYearSem;
 
     @FXML
     private Label moduleCardCredits;
@@ -37,7 +44,26 @@ public class ModuleCard extends UiPart<Region> {
     public ModuleCard(Module module) {
         super(FXML);
 
+        fillCard(module);
+    }
+
+    /**
+     * Instantiates a new placeholder ModuleCard. Purpose of this placeholder is to set the
+     * max width of the actual ModuleCards in ModuleGroup.
+     */
+    public ModuleCard() {
+        super(FXML);
+    }
+
+    /**
+     * Populate the ModuleCard with its information (module code, credits, yearsem, grade, tags)
+     * @param module The module object that encapsulates the module information.
+     */
+    private void fillCard(Module module) {
         moduleCardCode.setText(module.getCode().toString());
+
+        moduleCardYearSem.setText(module.getSemYear().toString());
+
         moduleCardCredits.setText(module.getCredit() + "MC");
 
         String grade = module.getGrade().toString();
@@ -49,14 +75,6 @@ public class ModuleCard extends UiPart<Region> {
             String color = ValidTag.getColor(tag.tagName);
             addTag(tagNameShort, tagNameLong, color);
         }
-    }
-
-    /**
-     * Instantiates a new placeholder ModuleCard. Purpose of this placeholder is to set the
-     * max width of the actual ModuleCards in ModuleGroup.
-     */
-    public ModuleCard() {
-        super(FXML);
     }
 
     /**

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleGroup.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleGroup.java
@@ -1,13 +1,12 @@
 package seedu.modtrek.ui.modulesection;
 
-import java.util.ArrayList;
-
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.modtrek.model.module.Module;
-import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.ui.UiPart;
 
 /**
@@ -17,7 +16,7 @@ public class ModuleGroup extends UiPart<Region> {
     private static final String FXML = "modulesection/ModuleGroup.fxml";
 
     @FXML
-    private Label moduleGroupTitle;
+    private VBox moduleGroup;
 
     @FXML
     private GridPane moduleCardGroup;
@@ -25,20 +24,24 @@ public class ModuleGroup extends UiPart<Region> {
     /**
      * Instantiates a new ModuleGroup.
      *
-     * @param sy the semYear
      * @param modules the list of modules for the semYear
+     * @param title title of the ModuleGroup
      */
-    public ModuleGroup(SemYear sy, ArrayList<Module> modules) {
+    public ModuleGroup(ObservableList<Module> modules, String title) {
         super(FXML);
-        moduleGroupTitle.setText(sy.toString());
-        displayModuleCards(modules);
+        displayModuleCards(modules, title);
     }
 
     /**
      * Displays all module cards within a module group.
      * @param modules the list of modules for the group
      */
-    public void displayModuleCards(ArrayList<Module> modules) {
+    public void displayModuleCards(ObservableList<Module> modules, String title) {
+        if (title.length() > 0) {
+            Label groupLabel = new Label(title);
+            groupLabel.getStyleClass().addAll("module-group-title", "h4");
+            moduleGroup.getChildren().add(0, groupLabel);
+        }
 
         /*
         * Position variables to keep track of the current free position (col, row) to add a ModuleCard on the GridPane.

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleList.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleList.java
@@ -1,9 +1,9 @@
 package seedu.modtrek.ui.modulesection;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -34,19 +34,26 @@ public class ModuleList extends UiPart<Region> {
         if (modules.size() == 0) {
             displayPlaceholderText(isFilteredList);
         }
-        displayModuleGroup(modules);
+        displayModuleGroup(modules, isFilteredList);
     }
 
     /**
      * Displays all module groups within a module list.
      * @param modules the list of modules
+     * @param isFilteredList indicates if the list of modules is filtered by a search query
      */
-    private void displayModuleGroup(ObservableList<Module> modules) {
-        HashMap<SemYear, ArrayList<Module>> modsPerSemYear = new HashMap<>();
+    private void displayModuleGroup(ObservableList<Module> modules, boolean isFilteredList) {
+        if (isFilteredList) {
+            ModuleGroup moduleGroup = new ModuleGroup(modules, "");
+            moduleList.getChildren().add(moduleGroup.getRoot());
+            return;
+        }
+
+        HashMap<SemYear, ObservableList<Module>> modsPerSemYear = new HashMap<>();
         for (Module module : modules) {
             SemYear semYear = module.getSemYear();
             if (!modsPerSemYear.containsKey(semYear)) {
-                ArrayList<Module> mods = new ArrayList<>();
+                ObservableList<Module> mods = FXCollections.observableArrayList();
                 mods.add(module);
                 modsPerSemYear.put(semYear, mods);
             } else {
@@ -54,8 +61,8 @@ public class ModuleList extends UiPart<Region> {
             }
         }
 
-        for (Map.Entry<SemYear, ArrayList<Module>> entry : modsPerSemYear.entrySet()) {
-            ModuleGroup moduleGroup = new ModuleGroup(entry.getKey(), entry.getValue());
+        for (Map.Entry<SemYear, ObservableList<Module>> entry : modsPerSemYear.entrySet()) {
+            ModuleGroup moduleGroup = new ModuleGroup(entry.getValue(), entry.getKey().toString());
             moduleList.getChildren().add(moduleGroup.getRoot());
         }
     }

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleList.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleList.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import seedu.modtrek.model.module.Module;
@@ -25,9 +26,14 @@ public class ModuleList extends UiPart<Region> {
      * Instantiates a new ModuleList.
      *
      * @param modules the entire list of modules
+     * @param isFilteredList indicates if the list of modules is filtered by a search query
      */
-    public ModuleList(ObservableList<Module> modules) {
+    public ModuleList(ObservableList<Module> modules, boolean isFilteredList) {
         super(FXML);
+
+        if (modules.size() == 0) {
+            displayPlaceholderText(isFilteredList);
+        }
         displayModuleGroup(modules);
     }
 
@@ -35,7 +41,7 @@ public class ModuleList extends UiPart<Region> {
      * Displays all module groups within a module list.
      * @param modules the list of modules
      */
-    public void displayModuleGroup(ObservableList<Module> modules) {
+    private void displayModuleGroup(ObservableList<Module> modules) {
         HashMap<SemYear, ArrayList<Module>> modsPerSemYear = new HashMap<>();
         for (Module module : modules) {
             SemYear semYear = module.getSemYear();
@@ -52,5 +58,21 @@ public class ModuleList extends UiPart<Region> {
             ModuleGroup moduleGroup = new ModuleGroup(entry.getKey(), entry.getValue());
             moduleList.getChildren().add(moduleGroup.getRoot());
         }
+    }
+
+    /**
+     * Displays the placeholder text message when no modules are present in the module list.
+     *
+     * @param isFilteredList indicates if the list of modules is filtered by a search query
+     */
+    private void displayPlaceholderText(boolean isFilteredList) {
+        String text;
+
+        text = isFilteredList ? "There are no modules that match your search query."
+                : "No modules found in the module list.";
+
+        Label placeholder = new Label(text);
+        placeholder.getStyleClass().add("h3");
+        moduleList.getChildren().add(placeholder);
     }
 }

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleListSection.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleListSection.java
@@ -15,7 +15,10 @@ public class ModuleListSection extends ModuleSection {
      * @param modules The modules to display in the section.
      */
     public ModuleListSection(ObservableList<Module> modules) {
-        super(modules);
+        super();
+
+        ModuleList moduleList = new ModuleList(modules, false);
+        moduleListPlaceholder.getChildren().add(moduleList.getRoot());
 
         ModuleSectionSortNav nav = new ModuleSectionSortNav();
         moduleSectionNav.getChildren().add(nav.getRoot());

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleSearchSection.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleSearchSection.java
@@ -16,7 +16,10 @@ public class ModuleSearchSection extends ModuleSection {
      * @param modules The modules to display in the section.
      */
     public ModuleSearchSection(ObservableList<Module> modules) {
-        super(modules);
+        super();
+
+        ModuleList moduleList = new ModuleList(modules, true);
+        moduleListPlaceholder.getChildren().add(moduleList.getRoot());
 
         ModuleSectionFindNav nav = new ModuleSectionFindNav();
         moduleSectionNav.getChildren().add(nav.getRoot());

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleSection.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleSection.java
@@ -1,11 +1,9 @@
 package seedu.modtrek.ui.modulesection;
 
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-import seedu.modtrek.model.module.Module;
 import seedu.modtrek.ui.UiPart;
 
 /**

--- a/src/main/java/seedu/modtrek/ui/modulesection/ModuleSection.java
+++ b/src/main/java/seedu/modtrek/ui/modulesection/ModuleSection.java
@@ -18,16 +18,12 @@ public class ModuleSection extends UiPart<Region> {
     protected HBox moduleSectionNav;
 
     @FXML
-    private StackPane moduleListPlaceholder;
+    protected StackPane moduleListPlaceholder;
 
     /**
      * Instantiates a ModuleSection.
-     * @param modules The list of modules to display in the ModuleSection.
      */
-    public ModuleSection(ObservableList<Module> modules) {
+    public ModuleSection() {
         super(FXML);
-
-        ModuleList moduleList = new ModuleList(modules);
-        moduleListPlaceholder.getChildren().add(moduleList.getRoot());
     }
 }

--- a/src/main/java/seedu/modtrek/ui/progresssection/DoughnutChart.java
+++ b/src/main/java/seedu/modtrek/ui/progresssection/DoughnutChart.java
@@ -61,7 +61,7 @@ public class DoughnutChart extends PieChart {
 
         List<String> tags = ValidTag.getTags();
         for (String tag : tags) {
-            int completeCredits = completeCreditsMap.get(tag);
+            int completeCredits = completeCreditsMap.get(ValidTag.getShortForm(tag).toString());
             int incompleteCredits = ValidTag.getTotalCredit(tag) - completeCredits;
             doughnutData.add(new PieChart.Data(tag, completeCredits));
             doughnutData.add(new PieChart.Data(tag, incompleteCredits));
@@ -105,12 +105,11 @@ public class DoughnutChart extends PieChart {
         innerCircle = new Circle();
         innerCircle.setStyle("-fx-fill: -black");
 
-        float percentCompleted = (float) degreeProgressionData.getCompletedCredit()
-                / degreeProgressionData.TOTALCREDIT * 100;
-        Text percent = new Text(Math.round(percentCompleted) + "% completed");
+        Text percent = new Text(degreeProgressionData.getOverallPercentage() + "% completed");
         percent.setStyle("-fx-fill: -teal;");
         percent.getStyleClass().add("h2");
 
+        // TODO: update this
         Text totalMc = new Text(degreeProgressionData.getCompletedCredit() + "/"
                 + degreeProgressionData.TOTALCREDIT + " MCs");
         totalMc.setStyle("-fx-fill: -white;");
@@ -340,16 +339,17 @@ public class DoughnutChart extends PieChart {
 
         Map<String, String> texts = new HashMap<>();
 
+        Map<String, Integer> requirementsPercentage = degreeProgressionData.getRequirementsPercentage();
+
         ObservableList<Data> doughnutData = getData();
+
         assert doughnutData.size() == Tag.NUM_TAGS * 2 : "Number of divisions of doughnut chart should be 12.";
         for (int i = 0; i < doughnutData.size(); i += 2) {
             Data completeData = doughnutData.get(i);
 
             String tag = ValidTag.getShortForm(completeData.getName()).toString();
 
-            double completeCredits = completeData.getPieValue();
-            double totalCredits = ValidTag.getTotalCredit(tag);
-            long percentCompleted = Math.round(completeCredits / totalCredits * 100);
+            int percentCompleted = requirementsPercentage.get(tag);
 
             String text = tagLongDisplay.get(tag) + "\n" + percentCompleted + "%";
             texts.put(tag, text);

--- a/src/main/java/seedu/modtrek/ui/resultssection/FooterButtonGroup.java
+++ b/src/main/java/seedu/modtrek/ui/resultssection/FooterButtonGroup.java
@@ -48,7 +48,7 @@ public class FooterButtonGroup extends UiPart<Region> {
 
 
         footerButtonGroup.getChildren().addAll(progressButton.getRoot(), getDeco(),
-                moduleListButton.getRoot(), moduleSearchButton.getRoot());
+                moduleListButton.getRoot(), getDeco(), moduleSearchButton.getRoot());
     }
 
     /**

--- a/src/main/java/seedu/modtrek/ui/resultssection/ResultsSection.java
+++ b/src/main/java/seedu/modtrek/ui/resultssection/ResultsSection.java
@@ -6,6 +6,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import seedu.modtrek.logic.Logic;
 import seedu.modtrek.model.ReadOnlyDegreeProgression;
 import seedu.modtrek.model.module.Module;
 import seedu.modtrek.ui.UiPart;
@@ -41,14 +42,15 @@ public class ResultsSection extends UiPart<Region> {
     /**
      * Creates a {@code ResultsSection} with the given {@code ObservableList<Module>}.
      */
-    public ResultsSection(ReadOnlyDegreeProgression degreeProgression, ObservableList<Module> modules) {
+    public ResultsSection(Logic logic) {
         super(FXML);
 
         displayFooter("Degree Progress", "Module List", "Module Search", () ->
-                displayProgress(degreeProgression), () ->
-                displayAllModules(modules), () -> displayFindModules(modules));
+                displayProgress(logic.getDegreeProgression()), () ->
+                displayAllModules(logic.getDegreeProgression().getModuleList()), () ->
+                displayFindModules(logic.getFilteredModuleList()));
 
-        displayProgress(degreeProgression);
+        displayProgress(logic.getDegreeProgression());
     }
 
     /**

--- a/src/main/resources/view/clisection/cli-section.css
+++ b/src/main/resources/view/clisection/cli-section.css
@@ -5,7 +5,8 @@
     -fx-pref-width: 480;
     -fx-padding: 0 30;
 
-    -fx-font-family: 'Courier Prime Bold';
+    -fx-font-family: 'Courier Prime Bold', sans-serif;
+    -fx-font-weight: 600;
     -fx-font-size: 14;
     -fx-text-fill: -white;
 }

--- a/src/main/resources/view/main-window.css
+++ b/src/main/resources/view/main-window.css
@@ -3,6 +3,7 @@
 
     -fx-font-family: 'Lexend Deca Medium', sans-serif;
     -fx-font-size: 12;
+    -fx-font-weight: 700;
 
     -fx-background-color: -black;
 }

--- a/src/main/resources/view/modulesection/ModuleCard.fxml
+++ b/src/main/resources/view/modulesection/ModuleCard.fxml
@@ -22,7 +22,7 @@
         <padding>
             <Insets top="10" bottom="10"/>
         </padding>
-        <HBox fx:id="moduleCardInfo" id="module-card-info">
+        <HBox id="module-card-info">
             <Label fx:id="moduleCardYearSem" styleClass="p1" />
             <Label fx:id="moduleCardCredits" styleClass="p1" />
             <Label fx:id="moduleCardGrade" styleClass="p1" />

--- a/src/main/resources/view/modulesection/ModuleCard.fxml
+++ b/src/main/resources/view/modulesection/ModuleCard.fxml
@@ -11,7 +11,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.FlowPane?>
 
-<VBox fx:id="moduleCard" GridPane.hgrow="always" GridPane.vgrow="always" alignment="CENTER" styleClass="module-card" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox GridPane.hgrow="always" GridPane.vgrow="always" alignment="CENTER" styleClass="module-card" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <stylesheets>
         <URL value="@module-card.css" />
     </stylesheets>

--- a/src/main/resources/view/modulesection/ModuleCard.fxml
+++ b/src/main/resources/view/modulesection/ModuleCard.fxml
@@ -9,9 +9,8 @@
 <?import javafx.scene.layout.HBox?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.FlowPane?>
+
 <VBox fx:id="moduleCard" GridPane.hgrow="always" GridPane.vgrow="always" alignment="CENTER" styleClass="module-card" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <stylesheets>
         <URL value="@module-card.css" />
@@ -23,9 +22,11 @@
         <padding>
             <Insets top="10" bottom="10"/>
         </padding>
-        <Label fx:id="moduleCardCredits" styleClass="p1" />
-        <Label text="        " styleClass="p1" />
-        <Label fx:id="moduleCardGrade" styleClass="p1" />
+        <HBox fx:id="moduleCardInfo" id="module-card-info">
+            <Label fx:id="moduleCardYearSem" styleClass="p1" />
+            <Label fx:id="moduleCardCredits" styleClass="p1" />
+            <Label fx:id="moduleCardGrade" styleClass="p1" />
+        </HBox>
     </HBox>
 
     <FlowPane alignment="CENTER" hgap="5" vgap="5" fx:id="moduleCardTagGroup" />

--- a/src/main/resources/view/modulesection/ModuleGroup.fxml
+++ b/src/main/resources/view/modulesection/ModuleGroup.fxml
@@ -7,11 +7,10 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox VBox.vgrow="ALWAYS" styleClass="module-group" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="moduleGroup" VBox.vgrow="ALWAYS" styleClass="module-group" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <stylesheets>
         <URL value="@module-group.css" />
     </stylesheets>
 
-    <Label fx:id="moduleGroupTitle" text="Y1S1" styleClass="module-group-title, h4" />
     <GridPane fx:id="moduleCardGroup" hgap="5" vgap="5" styleClass="module-card-group" />
 </VBox>

--- a/src/main/resources/view/modulesection/module-card.css
+++ b/src/main/resources/view/modulesection/module-card.css
@@ -1,6 +1,6 @@
 .module-card {
     -fx-min-height: 100;
-    -fx-padding: 10 25;
+    -fx-padding: 10 0;
 
     -fx-border-radius: 10;
     -fx-background-radius: 10;
@@ -12,6 +12,10 @@
 }
 .module-card-placeholder {
     visibility: hidden;
+}
+
+#module-card-info {
+    -fx-spacing: 12;
 }
 
 .module-card-tag {

--- a/src/main/resources/view/modulesection/module-card.css
+++ b/src/main/resources/view/modulesection/module-card.css
@@ -29,6 +29,9 @@
     -fx-border-radius: 7;
     -fx-background-radius: 7;
 }
+.module-card-tag:hover {
+    -fx-opacity: 0.75;
+}
 
 .module-card-tag-red {
     -fx-background-color: -tag-red;

--- a/src/main/resources/view/modulesection/module-card.css
+++ b/src/main/resources/view/modulesection/module-card.css
@@ -7,6 +7,9 @@
 
     -fx-background-color: -dark-grey;
 }
+.module-card:hover {
+    -fx-opacity: 1;
+}
 .module-card-incomplete {
     -fx-opacity: 0.5;
 }

--- a/src/main/resources/view/modulesection/module-group.css
+++ b/src/main/resources/view/modulesection/module-group.css
@@ -1,7 +1,7 @@
 .module-group-title {
     -fx-padding: 5 12;
 
-    -fx-font-family: 'Lexend Deca SemiBold';
+    -fx-font-family: 'Lexend Deca SemiBold', sans-serif;
     -fx-text-fill: -dark-grey;
 
     -fx-border-radius: 20;

--- a/src/main/resources/view/modulesection/module-list.css
+++ b/src/main/resources/view/modulesection/module-list.css
@@ -6,6 +6,6 @@
 }
 
 #module-list {
-    -fx-padding: 0 20 0 0;
+    -fx-padding: 0 15 0 0;
     -fx-spacing: 20;
 }

--- a/src/main/resources/view/modulesection/module-section.css
+++ b/src/main/resources/view/modulesection/module-section.css
@@ -24,7 +24,7 @@
 }
 
 .module-section-find-nav-filter-label {
-    -fx-padding: 5 10;
+    -fx-padding: 7 10;
 
     -fx-text-fill: -white;
     -fx-font-family: 'Courier Prime Bold', monospace;

--- a/src/main/resources/view/modulesection/module-section.css
+++ b/src/main/resources/view/modulesection/module-section.css
@@ -27,7 +27,8 @@
     -fx-padding: 7 10;
 
     -fx-text-fill: -white;
-    -fx-font-family: 'Courier Prime Bold', monospace;
+    -fx-font-family: 'Courier Prime Bold', sans-serif;
+    -fx-font-weight: 600;
 
     -fx-border-radius: 7;
     -fx-background-radius: 7;

--- a/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
@@ -14,49 +14,49 @@ public class HelpCommandTest {
 
     @Test
     public void execute_helpNoArgs_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_ALL_MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_ALL_MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpAdd_success() {
-        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpEdit_success() {
-        CommandResult expectedCommandResult = new CommandResult(EditCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(EditCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(EditCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpDelete_success() {
-        CommandResult expectedCommandResult = new CommandResult(DeleteCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(DeleteCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(DeleteCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpTag_success() {
-        CommandResult expectedCommandResult = new CommandResult(TagCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(TagCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(TagCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpList_success() {
-        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(ListCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpFind_success() {
-        CommandResult expectedCommandResult = new CommandResult(FindCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(FindCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(FindCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpExit_success() {
-        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_USAGE);
+        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_USAGE, false, false, false, false);
         assertCommandSuccess(new HelpCommand(ExitCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
@@ -14,49 +14,57 @@ public class HelpCommandTest {
 
     @Test
     public void execute_helpNoArgs_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_ALL_MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_ALL_MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpAdd_success() {
-        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(AddCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(AddCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpEdit_success() {
-        CommandResult expectedCommandResult = new CommandResult(EditCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(EditCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(EditCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpDelete_success() {
-        CommandResult expectedCommandResult = new CommandResult(DeleteCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(DeleteCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(DeleteCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpTag_success() {
-        CommandResult expectedCommandResult = new CommandResult(TagCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(TagCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(TagCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpList_success() {
-        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(ListCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpFind_success() {
-        CommandResult expectedCommandResult = new CommandResult(FindCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(FindCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(FindCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_helpExit_success() {
-        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_USAGE, false, false, false, false);
+        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_USAGE,
+                false, false, false, false);
         assertCommandSuccess(new HelpCommand(ExitCommand.MESSAGE_USAGE), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
When executing the various commands, the relevant screen on the left panel (`ResultsSection`) will be displayed:

- `view progress`: displays degree progress screen
- `find`: displays module search screen
- `help`, `exit`: screen remains as it is
- all other commands: displays module list screen