### PR TITLE
Prettify/Modify output messages

### DIFF
--- a/src/main/java/seedu/modtrek/commons/core/Messages.java
+++ b/src/main/java/seedu/modtrek/commons/core/Messages.java
@@ -6,7 +6,7 @@ package seedu.modtrek.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n\n%1$s";
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";
     public static final String MESSAGE_MODULES_LISTED_OVERVIEW = "%1$d modules listed!";
 

--- a/src/main/java/seedu/modtrek/logic/Logic.java
+++ b/src/main/java/seedu/modtrek/logic/Logic.java
@@ -1,6 +1,7 @@
 package seedu.modtrek.logic;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.modtrek.commons.core.GuiSettings;
@@ -23,6 +24,11 @@ public interface Logic {
      * @throws ParseException If an error occurs during parsing.
      */
     CommandResult execute(String commandText) throws CommandException, ParseException;
+
+    /**
+     * Returns the list of filters from find command
+     */
+    List<String> getFiltersList();
 
     /**
      * Returns the AddressBook.

--- a/src/main/java/seedu/modtrek/logic/LogicManager.java
+++ b/src/main/java/seedu/modtrek/logic/LogicManager.java
@@ -1,7 +1,11 @@
 package seedu.modtrek.logic;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -9,6 +13,7 @@ import seedu.modtrek.commons.core.GuiSettings;
 import seedu.modtrek.commons.core.LogsCenter;
 import seedu.modtrek.logic.commands.Command;
 import seedu.modtrek.logic.commands.CommandResult;
+import seedu.modtrek.logic.commands.FindCommand;
 import seedu.modtrek.logic.commands.exceptions.CommandException;
 import seedu.modtrek.logic.parser.ModTrekParser;
 import seedu.modtrek.logic.parser.exceptions.ParseException;
@@ -27,6 +32,7 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final ModTrekParser modTrekParser;
+    private List<String> filtersList;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -35,6 +41,7 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         modTrekParser = new ModTrekParser();
+        filtersList = new ArrayList<>();
     }
 
     @Override
@@ -43,6 +50,9 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command = modTrekParser.parseCommand(commandText);
+        if (command instanceof FindCommand) {
+            filtersList = ((FindCommand) command).getFiltersList();
+        }
         commandResult = command.execute(model);
 
         try {
@@ -55,10 +65,17 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public List<String> getFiltersList() {
+        requireNonNull(filtersList);
+        return filtersList;
+    }
+
+    @Override
     public ReadOnlyDegreeProgression getDegreeProgression() {
         return model.getDegreeProgression();
     }
 
+    @Override
     public ObservableList<Module> getFilteredModuleList() {
         return model.getFilteredModuleList();
     }

--- a/src/main/java/seedu/modtrek/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/AddCommand.java
@@ -18,23 +18,25 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds module to ModTrek.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds module to ModTrek.\n\n"
             + "Parameters: "
-            + PREFIX_CODE + "MODULE CODE "
-            + PREFIX_CREDIT + "MODULE CREDITS "
-            + PREFIX_SEMYEAR + "SEMESTER-YEAR "
-            + PREFIX_GRADE + "GRADE "
-            + "[" + PREFIX_TAG + "TAG...]\n"
+            + PREFIX_CODE + "<MODULE_CODE> "
+            + PREFIX_CREDIT + "<MODULE_CREDITS> "
+            + PREFIX_SEMYEAR + "<SEMESTER_YEAR> "
+            + "(" + PREFIX_GRADE + "<GRADE>) "
+            + "(" + PREFIX_TAG + "<TAG>...)\n\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_CODE + " CS1101S "
             + PREFIX_CREDIT + " 4 "
             + PREFIX_SEMYEAR + " Y1S1 "
             + PREFIX_GRADE + " A "
-            + PREFIX_TAG + " University Level Requirement "
-            + PREFIX_TAG + " Computer Science Foundation";
+            + PREFIX_TAG + " ULR "
+            + PREFIX_TAG + " CSF";
 
     public static final String MESSAGE_SUCCESS = "New module added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This module has already been added.Try using edit instead.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This module has already been added. Try using edit instead.";
+    public static final String MESSAGE_MISSING_PREFIXES =
+            "Missing code prefix /m, credit prefix /c, and/or sem-year prefix /y.";
 
     private final Module toAdd;
 

--- a/src/main/java/seedu/modtrek/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.modtrek.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.modtrek.model.Model.PREDICATE_SHOW_ALL_MODULES;
 
 import java.util.HashSet;
@@ -26,9 +27,10 @@ public class DeleteCommand extends Command {
      * The constant MESSAGE_USAGE.
      */
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the module identified by the module code.\n"
-            + "Parameters: {all} /m MODULE CODE\n"
-            + "Example: " + COMMAND_WORD + " /m CS1101S";
+            + ": Deletes all modules or the module identified by the module code.\n\n"
+            + "Parameters: (all) or (" + PREFIX_CODE + " <MODULE_CODE>)\n\n"
+            + "Example 1: " + COMMAND_WORD + " all\n"
+            + "Example 2: " + COMMAND_WORD + " " + PREFIX_CODE + " CS1101S";
 
     /**
      * The constant MESSAGE_DELETE_MODULE_SUCCESS.
@@ -85,7 +87,16 @@ public class DeleteCommand extends Command {
         String notFoundModules = String.format(MESSAGE_DELETE_MODULE_NOT_FOUND, codesNotFound);
 
         model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
-        return new CommandResult(deletedModules + "\n" + notFoundModules);
+        String message;
+        if (codesFound.isEmpty()) {
+            throw new CommandException(notFoundModules);
+        }
+        if (codesNotFound.isEmpty()) {
+            message = deletedModules;
+        } else {
+            message = deletedModules + "\n" + notFoundModules;
+        }
+        return new CommandResult(message);
     }
 
     @Override

--- a/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
@@ -1,6 +1,7 @@
 package seedu.modtrek.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CREDIT;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_SEMYEAR;
@@ -31,12 +32,13 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the module identified. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: MODULE CODE "
-            + "[" + PREFIX_CREDIT + "CREDITS] "
-            + "[" + PREFIX_SEMYEAR + "SEMESTER-YEAR] "
-            + "[" + PREFIX_GRADE + "GRADE] "
-            + "[" + PREFIX_TAG + "TAG...]\n"
+            + "Existing values will be overwritten by the input values.\n\n"
+            + "Parameters: MODULE_CODE "
+            + "(" + PREFIX_CODE + " <MODULE_CODE>) "
+            + "(" + PREFIX_CREDIT + " <MODULE_CREDITS>) "
+            + "(" + PREFIX_SEMYEAR + " <SEMESTER_YEAR>) "
+            + "(" + PREFIX_GRADE + "<GRADE>) "
+            + "(" + PREFIX_TAG + "<TAG>...)\n\n"
             + "Example: " + COMMAND_WORD + " CS2106 "
             + PREFIX_CREDIT + " 4 "
             + PREFIX_SEMYEAR + " Y2S2";
@@ -44,7 +46,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the grade book.";
-    public static final String MESSAGE_EDIT_MODULE_FAIL = "Module %1$s is not yet added";
+    public static final String MESSAGE_EDIT_MODULE_FAIL = "Module %1$s is not yet added.";
 
     private final Code code;
     private final EditModuleDescriptor editModuleDescriptor;

--- a/src/main/java/seedu/modtrek/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/ExitCommand.java
@@ -11,8 +11,8 @@ public class ExitCommand extends Command {
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting ModTrek as requested ...";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits ModTrek.\n"
-            + "Parameters: NIL\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits ModTrek.\n\n"
+            + "Parameters: NIL\n\n"
             + "Example: " + COMMAND_WORD;
 
     @Override

--- a/src/main/java/seedu/modtrek/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/FindCommand.java
@@ -20,13 +20,13 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds module with the specified module code "
-            + "or by its prefix, credits, semyear, grade, tag(s).\n"
-            + "Parameters: [MODULE CODE] or "
-            + "[" + PREFIX_CODE + " MODULE PREFIX] "
-            + "[" + PREFIX_CREDIT + " MODULE CREDITS] "
-            + "[" + PREFIX_SEMYEAR + " SEMESTER-YEAR] "
-            + "[" + PREFIX_GRADE + " GRADE] "
-            + "[" + PREFIX_TAG + " TAG...]\n"
+            + "or by its prefix, credits, semyear, grade, tag(s).\n\n"
+            + "Parameters: (<MODULE_CODE>) or "
+            + "(" + PREFIX_CODE + " <MODULE_PREFIX>) "
+            + "(" + PREFIX_CREDIT + " <MODULE_CREDITS>) "
+            + "(" + PREFIX_SEMYEAR + " <SEMESTER_YEAR>) "
+            + "(" + PREFIX_GRADE + " <GRADE>) "
+            + "(" + PREFIX_TAG + " <TAG>...)\n\n"
             + "Example 1: " + COMMAND_WORD + " CS1101S\n"
             + "Example 2: " + COMMAND_WORD + " /m CS /g A";
 

--- a/src/main/java/seedu/modtrek/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/FindCommand.java
@@ -7,6 +7,8 @@ import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_SEMYEAR;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
+
 import seedu.modtrek.commons.core.Messages;
 import seedu.modtrek.model.Model;
 import seedu.modtrek.model.module.ModuleCodePredicate;
@@ -31,9 +33,20 @@ public class FindCommand extends Command {
             + "Example 2: " + COMMAND_WORD + " /m CS /g A";
 
     private final ModuleCodePredicate predicate;
+    private final List<String> filtersList;
 
-    public FindCommand(ModuleCodePredicate predicate) {
+    /**
+     * Creates a FindCommand object.
+     * @param predicate condition that satisfies the filters of the prefixes
+     * @param filtersList list of filters
+     */
+    public FindCommand(ModuleCodePredicate predicate, List<String> filtersList) {
         this.predicate = predicate;
+        this.filtersList = filtersList;
+    }
+
+    public List<String> getFiltersList() {
+        return filtersList;
     }
 
     @Override

--- a/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
@@ -9,19 +9,22 @@ public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the usage of command(s).\n"
-            + "Parameters: COMMAND (Optional)\n"
-            + "Example: " + COMMAND_WORD + " add";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the usage of command(s).\n\n"
+            + "Parameters: (COMMAND)\n\n"
+            + "Example 1: " + COMMAND_WORD
+            + "\nExample 2: " + COMMAND_WORD + " add";
 
-    public static final String SHOWING_HELP_MESSAGE = "Here is a summary of all our commands:\n\n";
+    public static final String SHOWING_HELP_MESSAGE = "Here is a list of all our help commands. "
+            + "If you require more information, type in the command to find out more.\n";
 
-    public static final String SHOWING_ALL_MESSAGE_USAGE = SHOWING_HELP_MESSAGE + AddCommand.MESSAGE_USAGE
-            + "\n\n" + EditCommand.MESSAGE_USAGE
-            + "\n\n" + DeleteCommand.MESSAGE_USAGE
-            + "\n\n" + TagCommand.MESSAGE_USAGE
-            + "\n\n" + ListCommand.MESSAGE_USAGE
-            + "\n\n" + FindCommand.MESSAGE_USAGE
-            + "\n\n" + ExitCommand.MESSAGE_USAGE;
+    public static final String SHOWING_ALL_MESSAGE_USAGE = SHOWING_HELP_MESSAGE
+            + "\n" + COMMAND_WORD + " " + AddCommand.COMMAND_WORD
+            + "\n" + COMMAND_WORD + " " + EditCommand.COMMAND_WORD
+            + "\n" + COMMAND_WORD + " " + DeleteCommand.COMMAND_WORD
+            + "\n" + COMMAND_WORD + " " + TagCommand.COMMAND_WORD
+            + "\n" + COMMAND_WORD + " " + ViewCommand.COMMAND_WORD
+            + "\n" + COMMAND_WORD + " " + FindCommand.COMMAND_WORD
+            + "\n" + COMMAND_WORD + " " + ExitCommand.COMMAND_WORD;
 
     private final String selectedMessage;
 

--- a/src/main/java/seedu/modtrek/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/TagCommand.java
@@ -26,28 +26,28 @@ public class TagCommand extends Command {
      * The constant MESSAGE_ARGUMENTS.
      */
     public static final String MESSAGE_ARGUMENTS = "Module Code: %1$d, Tag: %2$s";
+
     /**
      * The constant MESSAGE_USAGE.
      */
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds tags to the module identified.\n"
-            + "Parameters: CODE (module code) include/remove\n"
-            + "Example: " + COMMAND_WORD + " CS1101S " + "include "
-            + "/t UNIVERSITY LEVEL REQUIREMENTS";
+            + ": Adds tags to the module identified.\n\n"
+            + "Parameters: <MODULE_CODE> include/remove /t <TAG>...\n\n"
+            + "Example 1: " + COMMAND_WORD + " CS1101S " + "include " + "/t ULR\n"
+            + "Example 2: " + COMMAND_WORD + " MA2001 " + "remove " + "/t CSF";
 
-    /**
-     * The constant MESSAGE_NOT_IMPLEMENTED_YET.
-     */
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
-            "Tag command not implemented yet";
     /**
      * The constant MESSAGE_ADD_TAG_SUCCESS.
      */
     public static final String MESSAGE_ADD_TAG_SUCCESS = "Added tag to Module: %1$s";
+
     /**
      * The constant MESSAGE_ADD_TAG_FAILURE.
      */
     public static final String MESSAGE_REMOVE_TAG_SUCCESS = "Removed tag from Module: %1$s";
+
+    public static final String MESSAGE_MISSING_PREFIX =
+            "Missing tag prefix /t.";
 
     private final Code code;
     private final boolean isInclude;

--- a/src/main/java/seedu/modtrek/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/ViewCommand.java
@@ -16,9 +16,10 @@ public class ViewCommand extends Command {
 
     public static final String MESSAGE_MODULES_SUCCESS = "Listed all modules";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Switches between different viewing screens.\n"
-            + "Parameters: progress / modules\n"
-            + "Example: view progress";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Switches between different viewing screens.\n\n"
+            + "Parameters: progress or modules\n\n"
+            + "Example 1: view progress\n"
+            + "Example 2: view modules";
 
     private final boolean isProgress;
 

--- a/src/main/java/seedu/modtrek/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/AddCommandParser.java
@@ -36,12 +36,16 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG);
 
-        if (!argMultimap.getPreamble().isEmpty() || args.isEmpty()) {
+        if (args.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR)) {
             throw new ParseException(AddCommand.MESSAGE_MISSING_PREFIXES);
+        }
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         String codeString = argMultimap.getValue(PREFIX_CODE).get();
@@ -62,11 +66,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
         SemYear semYear = ParserUtil.parseSemYear(semYearString);
 
-        boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
         String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
-        if (isGradePresent && gradeString.isEmpty()) {
-            throw new ParseException(Grade.MESSAGE_MISSING_DETAIL);
-        }
         Grade grade = ParserUtil.parseGrade(gradeString);
 
         boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();

--- a/src/main/java/seedu/modtrek/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/AddCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.modtrek.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CREDIT;
@@ -30,18 +31,48 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.getPreamble().isEmpty() || args.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        Code code = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get());
-        Credit credit = ParserUtil.parseCredit(argMultimap.getValue(PREFIX_CREDIT).get());
-        SemYear semYear = ParserUtil.parseSemYear(argMultimap.getValue(PREFIX_SEMYEAR).get());
-        Grade grade = ParserUtil.parseGrade(argMultimap.getValue(PREFIX_GRADE).orElse(""));
+        if (!arePrefixesPresent(argMultimap, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR)) {
+            throw new ParseException(AddCommand.MESSAGE_MISSING_PREFIXES);
+        }
+
+        String codeString = argMultimap.getValue(PREFIX_CODE).get();
+        if (codeString.isEmpty()) {
+            throw new ParseException(Code.MESSAGE_MISSING_DETAIL);
+        }
+        Code code = ParserUtil.parseCode(codeString);
+
+        String creditString = argMultimap.getValue(PREFIX_CREDIT).get();
+        if (creditString.isEmpty()) {
+            throw new ParseException(Credit.MESSAGE_MISSING_DETAIL);
+        }
+        Credit credit = ParserUtil.parseCredit(creditString);
+
+        String semYearString = argMultimap.getValue(PREFIX_SEMYEAR).get();
+        if (semYearString.isEmpty()) {
+            throw new ParseException(SemYear.MESSAGE_MISSING_DETAIL);
+        }
+        SemYear semYear = ParserUtil.parseSemYear(semYearString);
+
+        boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
+        String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
+        if (isGradePresent && gradeString.isEmpty()) {
+            throw new ParseException(Grade.MESSAGE_MISSING_DETAIL);
+        }
+        Grade grade = ParserUtil.parseGrade(gradeString);
+
+        boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
+        if (isTagPresent && argMultimap.getAllValues(PREFIX_TAG).contains("")) {
+            throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
+        }
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Module module = new Module(code, credit, semYear, tagList, grade);

--- a/src/main/java/seedu/modtrek/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/DeleteCommandParser.java
@@ -23,25 +23,27 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CODE);
-        try {
-            boolean isAll;
-            Set<Code> codes;
-            String flag = argumentMultimap.getPreamble();
-            if (flag.equals("all")) {
-                isAll = true;
-                codes = new HashSet<>();
-            } else if (flag.isEmpty() && argumentMultimap.getValue(PREFIX_CODE).isPresent()) {
-                isAll = false;
-                codes = ParserUtil.parseCodes(argumentMultimap.getAllValues(PREFIX_CODE));
-            } else {
-                throw new ParseException("Incorrect format");
-            }
-            return new DeleteCommand(isAll, codes);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CODE);
+
+        boolean isAll;
+        Set<Code> codes;
+        String flag = argMultimap.getPreamble();
+        boolean isCodePrefixPresent = argMultimap.getValue(PREFIX_CODE).isPresent();
+        String codeString = argMultimap.getValue(PREFIX_CODE).orElse("");
+        if (isCodePrefixPresent && codeString.isEmpty()) {
+            throw new ParseException(Code.MESSAGE_MISSING_DETAIL);
         }
+        if (flag.equals("all")) {
+            isAll = true;
+            codes = new HashSet<>();
+        } else if (flag.isEmpty() && !codeString.isEmpty()) {
+            isAll = false;
+            codes = ParserUtil.parseCodes(argMultimap.getAllValues(PREFIX_CODE));
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+        return new DeleteCommand(isAll, codes);
     }
 
 }

--- a/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
@@ -74,19 +74,10 @@ public class EditCommandParser implements Parser<EditCommand> {
             editModuleDescriptor.setSemYear(ParserUtil.parseSemYear(argMultimap.getValue(PREFIX_SEMYEAR).get()));
         }
 
-        boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
-        String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
-        if (isGradePresent && gradeString.isEmpty()) {
-            throw new ParseException(Grade.MESSAGE_MISSING_DETAIL);
-        }
-        if (!gradeString.isEmpty()) {
+        if (argMultimap.getValue(PREFIX_GRADE).isPresent()) {
             editModuleDescriptor.setGrade(ParserUtil.parseGrade(argMultimap.getValue(PREFIX_GRADE).get()));
         }
 
-        boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
-        if (isTagPresent && argMultimap.getAllValues(PREFIX_TAG).contains("")) {
-            throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
-        }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editModuleDescriptor::setTags);
 
         if (!editModuleDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
@@ -17,6 +17,9 @@ import seedu.modtrek.logic.commands.EditCommand;
 import seedu.modtrek.logic.commands.EditCommand.EditModuleDescriptor;
 import seedu.modtrek.logic.parser.exceptions.ParseException;
 import seedu.modtrek.model.module.Code;
+import seedu.modtrek.model.module.Credit;
+import seedu.modtrek.model.module.Grade;
+import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.model.tag.Tag;
 
 /**
@@ -31,29 +34,58 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG);
 
-        Code code;
-
-        try {
-            code = ParserUtil.parseCode(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        String preamble = argMultimap.getPreamble();
+        if (preamble.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
+
+        Code code = ParserUtil.parseCode(preamble);
 
         EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
-        if (argMultimap.getValue(PREFIX_CODE).isPresent()) {
+
+        boolean isCodePrefixPresent = argMultimap.getValue(PREFIX_CODE).isPresent();
+        String codeString = argMultimap.getValue(PREFIX_CODE).orElse("");
+        if (isCodePrefixPresent && codeString.isEmpty()) {
+            throw new ParseException(Code.MESSAGE_MISSING_DETAIL);
+        }
+        if (!codeString.isEmpty()) {
             editModuleDescriptor.setCode(ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get()));
         }
-        if (argMultimap.getValue(PREFIX_CREDIT).isPresent()) {
+
+        boolean isCreditPrefixPresent = argMultimap.getValue(PREFIX_CREDIT).isPresent();
+        String creditString = argMultimap.getValue(PREFIX_CREDIT).orElse("");
+        if (isCreditPrefixPresent && creditString.isEmpty()) {
+            throw new ParseException(Credit.MESSAGE_MISSING_DETAIL);
+        }
+        if (!creditString.isEmpty()) {
             editModuleDescriptor.setCredit(ParserUtil.parseCredit(argMultimap.getValue(PREFIX_CREDIT).get()));
         }
-        if (argMultimap.getValue(PREFIX_SEMYEAR).isPresent()) {
+
+        boolean isSemYearPresent = argMultimap.getValue(PREFIX_SEMYEAR).isPresent();
+        String semYearString = argMultimap.getValue(PREFIX_SEMYEAR).orElse("");
+        if (isSemYearPresent && semYearString.isEmpty()) {
+            throw new ParseException(SemYear.MESSAGE_MISSING_DETAIL);
+        }
+        if (!semYearString.isEmpty()) {
             editModuleDescriptor.setSemYear(ParserUtil.parseSemYear(argMultimap.getValue(PREFIX_SEMYEAR).get()));
         }
-        if (argMultimap.getValue(PREFIX_GRADE).isPresent()) {
+
+        boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
+        String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
+        if (isGradePresent && gradeString.isEmpty()) {
+            throw new ParseException(Grade.MESSAGE_MISSING_DETAIL);
+        }
+        if (!gradeString.isEmpty()) {
             editModuleDescriptor.setGrade(ParserUtil.parseGrade(argMultimap.getValue(PREFIX_GRADE).get()));
+        }
+
+        boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
+        if (isTagPresent && argMultimap.getAllValues(PREFIX_TAG).contains("")) {
+            throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editModuleDescriptor::setTags);
 

--- a/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
@@ -18,7 +18,6 @@ import seedu.modtrek.logic.commands.EditCommand.EditModuleDescriptor;
 import seedu.modtrek.logic.parser.exceptions.ParseException;
 import seedu.modtrek.model.module.Code;
 import seedu.modtrek.model.module.Credit;
-import seedu.modtrek.model.module.Grade;
 import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.model.tag.Tag;
 

--- a/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
@@ -8,7 +8,9 @@ import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_SEMYEAR;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.modtrek.logic.commands.FindCommand;
@@ -41,6 +43,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG);
 
+        List<String> filtersList = new ArrayList<>();
+
         boolean isModulePrefixPresent = argMultimap.getValue(PREFIX_CODE).isPresent();
         String codePrefixString = argMultimap.getValue(PREFIX_CODE).orElse("");
         if (isModulePrefixPresent && codePrefixString.isEmpty()) {
@@ -48,6 +52,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
         if (!codePrefixString.isEmpty()) {
             codePrefixString = ParserUtil.parseCodePrefix(codePrefixString).toString();
+            filtersList.add(PREFIX_CODE + " " + codePrefixString);
         }
 
         boolean isCreditPrefixPresent = argMultimap.getValue(PREFIX_CREDIT).isPresent();
@@ -57,6 +62,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
         if (!creditString.isEmpty()) {
             creditString = ParserUtil.parseCredit(creditString).toString();
+            filtersList.add(PREFIX_CREDIT + " " + creditString);
         }
 
         boolean isSemYearPresent = argMultimap.getValue(PREFIX_SEMYEAR).isPresent();
@@ -66,6 +72,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
         if (!semYearString.isEmpty()) {
             semYearString = ParserUtil.parseSemYear(semYearString).toString();
+            filtersList.add(PREFIX_SEMYEAR + " " + semYearString);
         }
 
         boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
@@ -75,6 +82,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
         if (!gradeString.isEmpty()) {
             gradeString = ParserUtil.parseGrade(gradeString).toString();
+            filtersList.add(PREFIX_GRADE + " " + gradeString);
         }
 
         boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
@@ -82,6 +90,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
         }
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        for (Tag tag : tagList) {
+            filtersList.add(PREFIX_TAG + " " + tag.tagName);
+        }
 
         ModuleCodePredicate moduleCodePredicate;
         if (!argMultimap.getPreamble().isEmpty()) {
@@ -92,7 +103,8 @@ public class FindCommandParser implements Parser<FindCommand> {
             moduleCodePredicate = new ModuleCodePredicate(codePrefixString, creditString,
                     semYearString, gradeString, (HashSet<Tag>) tagList);
         }
-        return new FindCommand(moduleCodePredicate);
+
+        return new FindCommand(moduleCodePredicate, filtersList);
     }
 
 }

--- a/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.modtrek.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CREDIT;
@@ -13,7 +14,11 @@ import java.util.Set;
 import seedu.modtrek.logic.commands.FindCommand;
 import seedu.modtrek.logic.parser.exceptions.ParseException;
 import seedu.modtrek.model.module.Code;
+import seedu.modtrek.model.module.CodePrefix;
+import seedu.modtrek.model.module.Credit;
+import seedu.modtrek.model.module.Grade;
 import seedu.modtrek.model.module.ModuleCodePredicate;
+import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.model.tag.Tag;
 
 /**
@@ -27,7 +32,9 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
+        requireNonNull(args);
+
+        if (args.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
@@ -37,49 +44,54 @@ public class FindCommandParser implements Parser<FindCommand> {
         boolean isModulePrefixPresent = argMultimap.getValue(PREFIX_CODE).isPresent();
         String codePrefixString = argMultimap.getValue(PREFIX_CODE).orElse("");
         if (isModulePrefixPresent && codePrefixString.isEmpty()) {
-            throw new ParseException("Missing module code prefix after /m");
+            throw new ParseException(CodePrefix.MESSAGE_MISSING_DETAIL);
         }
         if (!codePrefixString.isEmpty()) {
             codePrefixString = ParserUtil.parseCodePrefix(codePrefixString).toString();
         }
+
         boolean isCreditPrefixPresent = argMultimap.getValue(PREFIX_CREDIT).isPresent();
         String creditString = argMultimap.getValue(PREFIX_CREDIT).orElse("");
         if (isCreditPrefixPresent && creditString.isEmpty()) {
-            throw new ParseException("Missing credit after /c");
+            throw new ParseException(Credit.MESSAGE_MISSING_DETAIL);
         }
         if (!creditString.isEmpty()) {
             creditString = ParserUtil.parseCredit(creditString).toString();
         }
+
         boolean isSemYearPresent = argMultimap.getValue(PREFIX_SEMYEAR).isPresent();
         String semYearString = argMultimap.getValue(PREFIX_SEMYEAR).orElse("");
         if (isSemYearPresent && semYearString.isEmpty()) {
-            throw new ParseException("Missing semyear after /y");
+            throw new ParseException(SemYear.MESSAGE_MISSING_DETAIL);
         }
         if (!semYearString.isEmpty()) {
             semYearString = ParserUtil.parseSemYear(semYearString).toString();
         }
+
         boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
         String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
         if (isGradePresent && gradeString.isEmpty()) {
-            throw new ParseException("Missing grade after /g");
+            throw new ParseException(Grade.MESSAGE_MISSING_DETAIL);
         }
         if (!gradeString.isEmpty()) {
             gradeString = ParserUtil.parseGrade(gradeString).toString();
         }
+
         boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
         if (isTagPresent && argMultimap.getAllValues(PREFIX_TAG).contains("")) {
-            throw new ParseException("Missing tag after /t");
+            throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
         }
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        ModuleCodePredicate moduleCodePredicate;
         if (!argMultimap.getPreamble().isEmpty()) {
             Code code = ParserUtil.parseCode(argMultimap.getPreamble());
-            ModuleCodePredicate moduleCodePredicate = new ModuleCodePredicate(code.toString(), "",
+            moduleCodePredicate = new ModuleCodePredicate(code.toString(), "",
                     "", "", new HashSet<>());
-            return new FindCommand(moduleCodePredicate);
+        } else {
+            moduleCodePredicate = new ModuleCodePredicate(codePrefixString, creditString,
+                    semYearString, gradeString, (HashSet<Tag>) tagList);
         }
-        ModuleCodePredicate moduleCodePredicate = new ModuleCodePredicate(codePrefixString, creditString,
-                semYearString, gradeString, (HashSet<Tag>) tagList);
         return new FindCommand(moduleCodePredicate);
     }
 

--- a/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
@@ -99,6 +99,8 @@ public class FindCommandParser implements Parser<FindCommand> {
             Code code = ParserUtil.parseCode(argMultimap.getPreamble());
             moduleCodePredicate = new ModuleCodePredicate(code.toString(), "",
                     "", "", new HashSet<>());
+            filtersList.clear();
+            filtersList.add(code.toString());
         } else {
             moduleCodePredicate = new ModuleCodePredicate(codePrefixString, creditString,
                     semYearString, gradeString, (HashSet<Tag>) tagList);

--- a/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.modtrek.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.modtrek.logic.commands.AddCommand;
@@ -8,8 +9,8 @@ import seedu.modtrek.logic.commands.EditCommand;
 import seedu.modtrek.logic.commands.ExitCommand;
 import seedu.modtrek.logic.commands.FindCommand;
 import seedu.modtrek.logic.commands.HelpCommand;
-import seedu.modtrek.logic.commands.ListCommand;
 import seedu.modtrek.logic.commands.TagCommand;
+import seedu.modtrek.logic.commands.ViewCommand;
 import seedu.modtrek.logic.parser.exceptions.ParseException;
 
 /**
@@ -23,6 +24,8 @@ public class HelpCommandParser implements Parser<HelpCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public HelpCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             return new HelpCommand("");
@@ -36,8 +39,8 @@ public class HelpCommandParser implements Parser<HelpCommand> {
                 return new HelpCommand(DeleteCommand.MESSAGE_USAGE);
             case "TAG":
                 return new HelpCommand(TagCommand.MESSAGE_USAGE);
-            case "LIST":
-                return new HelpCommand(ListCommand.MESSAGE_USAGE);
+            case "VIEW":
+                return new HelpCommand(ViewCommand.MESSAGE_USAGE);
             case "FIND":
                 return new HelpCommand(FindCommand.MESSAGE_USAGE);
             case "EXIT":

--- a/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.modtrek.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Locale;
@@ -17,33 +18,36 @@ import seedu.modtrek.model.tag.Tag;
 public class TagCommandParser implements Parser<TagCommand> {
     /**
      * Parses {@code userInput} into a command and returns it.
-     *
-     * @param args
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
     @Override
     public TagCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TAG);
 
-        Code code;
         boolean isInclude;
 
         String preamble = argMultimap.getPreamble();
         String[] preambleParts = preamble.split(" ");
-        code = ParserUtil.parseCode(preambleParts[0]);
         if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("include")) {
             isInclude = true;
         } else if (preambleParts.length > 1 && preambleParts[1].toLowerCase(Locale.ROOT).equals("remove")) {
             isInclude = false;
         } else {
-            throw new ParseException("Did not specify whether to include or remove tags");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
+        }
+        Code code = ParserUtil.parseCode(preambleParts[0]);
+
+        boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
+        if (!isTagPresent) {
+            throw new ParseException(TagCommand.MESSAGE_MISSING_PREFIX);
+        }
+        if (argMultimap.getAllValues(PREFIX_TAG).contains("")) {
+            throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
         }
         Set<Tag> tag = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        if (tag.isEmpty()) {
-            throw new ParseException("Did not specify prefix /t");
-        }
         return new TagCommand(code, isInclude, tag);
     }
 }

--- a/src/main/java/seedu/modtrek/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/ViewCommandParser.java
@@ -18,6 +18,7 @@ public class ViewCommandParser implements Parser<ViewCommand> {
      */
     public ViewCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
         String[] trimmedArgs = args.trim().split(" ");
         if (trimmedArgs.length == 1) {
             String flag = trimmedArgs[0];

--- a/src/main/java/seedu/modtrek/model/module/Code.java
+++ b/src/main/java/seedu/modtrek/model/module/Code.java
@@ -9,7 +9,9 @@ import static seedu.modtrek.commons.util.AppUtil.checkArgument;
 public class Code {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Module code is missing, invalid or at the wrong position. It should be alphanumeric.";
+            "Module code is invalid. It should be alphanumeric.";
+
+    public static final String MESSAGE_MISSING_DETAIL = "Missing module code after /m.";
 
     private static final String VALIDATION_REGEX = "^[A-Z]{2,4}[0-9]{4}[A-Z]{0,1}$";
 

--- a/src/main/java/seedu/modtrek/model/module/CodePrefix.java
+++ b/src/main/java/seedu/modtrek/model/module/CodePrefix.java
@@ -14,6 +14,8 @@ public class CodePrefix {
     public static final String MESSAGE_CONSTRAINTS =
             "Module code prefix is invalid. It should be between 2 and 4 alphabetic characters.";
 
+    public static final String MESSAGE_MISSING_DETAIL = "Missing module code prefix after /m.";
+
     private static final String VALIDATION_REGEX = "^[A-Z]{2,4}$";
 
     /**

--- a/src/main/java/seedu/modtrek/model/module/Credit.java
+++ b/src/main/java/seedu/modtrek/model/module/Credit.java
@@ -11,7 +11,7 @@ public class Credit {
     public static final String MESSAGE_CONSTRAINTS =
             "Credit should only be a number and only 1-2 digits long.";
 
-    public static final String MESSAGE_MISSING_DETAIL = "Missing credit after /m.";
+    public static final String MESSAGE_MISSING_DETAIL = "Missing credit after /c.";
 
     private static final String VALIDATION_REGEX = "\\d{1,2}";
 

--- a/src/main/java/seedu/modtrek/model/module/Credit.java
+++ b/src/main/java/seedu/modtrek/model/module/Credit.java
@@ -9,7 +9,9 @@ import static seedu.modtrek.commons.util.AppUtil.checkArgument;
 public class Credit {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Credit should only be a number and only 1-2 digits long";
+            "Credit should only be a number and only 1-2 digits long.";
+
+    public static final String MESSAGE_MISSING_DETAIL = "Missing credit after /m.";
 
     private static final String VALIDATION_REGEX = "\\d{1,2}";
 

--- a/src/main/java/seedu/modtrek/model/module/Grade.java
+++ b/src/main/java/seedu/modtrek/model/module/Grade.java
@@ -12,7 +12,9 @@ import java.util.Set;
 public class Grade {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Grade should be either one of [A+, A, A-, B+, B, B-, C+, C, D+, D, F, S, U]";
+            "Grade should be either one of [A+, A, A-, B+, B, B-, C+, C, D+, D, F, S, U].";
+
+    public static final String MESSAGE_MISSING_DETAIL = "Missing grade after /g.";
 
     private static Map<String, Double> gradeToPoints = Map.ofEntries(
         Map.entry("A+", 5.0),

--- a/src/main/java/seedu/modtrek/model/module/Module.java
+++ b/src/main/java/seedu/modtrek/model/module/Module.java
@@ -124,22 +124,23 @@ public class Module {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(code)
+        builder.append("\nCode: ")
+                .append(code)
                 .append("; Credits: ")
                 .append(credits)
                 .append("; Year-Semester: ")
                 .append(semesterYear);
 
+        if (!grade.isEmpty()) {
+            builder.append("; Grade: ")
+                    .append(grade);
+        }
+
         if (!tags.isEmpty()) {
             builder.append("; Tags:");
             for (Tag tag : tags) {
-                builder.append(" ").append(tag);
+                builder.append(" [").append(tag).append("]");
             }
-        }
-
-        if (grade != null) {
-            builder.append("; Grade: ")
-                    .append(grade);
         }
 
         return builder.toString();

--- a/src/main/java/seedu/modtrek/model/module/SemYear.java
+++ b/src/main/java/seedu/modtrek/model/module/SemYear.java
@@ -9,7 +9,9 @@ import static seedu.modtrek.commons.util.AppUtil.checkArgument;
 public class SemYear {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "SemYear should be alphanumeric in the format YxS(T)x, where x are digits";
+            "SemYear should be alphanumeric in the format YxS(T)x, where x are digits.";
+
+    public static final String MESSAGE_MISSING_DETAIL = "Missing sem-year after /y.";
 
     private static final String VALIDATION_REGEX = "^Y[0-5]S[T]{0,1}[1-2]$";
 

--- a/src/main/java/seedu/modtrek/model/tag/Tag.java
+++ b/src/main/java/seedu/modtrek/model/tag/Tag.java
@@ -13,6 +13,8 @@ public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be one of possible curriculum requirements";
 
+    public static final String MESSAGE_MISSING_DETAIL = "Missing tag after /t.";
+
     public final String tagName;
 
 

--- a/src/main/java/seedu/modtrek/model/tag/Tag.java
+++ b/src/main/java/seedu/modtrek/model/tag/Tag.java
@@ -11,7 +11,7 @@ public class Tag {
 
     public static final int NUM_TAGS = 6;
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be one of possible curriculum requirements";
+    public static final String MESSAGE_CONSTRAINTS = "Tag name should be one of possible curriculum requirements.";
 
     public static final String MESSAGE_MISSING_DETAIL = "Missing tag after /t.";
 

--- a/src/test/java/seedu/modtrek/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/modtrek/logic/LogicManagerTest.java
@@ -11,11 +11,14 @@ import static seedu.modtrek.testutil.TypicalModules.CS1101S;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import seedu.modtrek.commons.core.Messages;
 import seedu.modtrek.logic.commands.AddCommand;
 import seedu.modtrek.logic.commands.CommandResult;
 import seedu.modtrek.logic.commands.ListCommand;
@@ -48,6 +51,22 @@ public class LogicManagerTest {
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
+    }
+
+    @Test
+    public void execute_findCommandGetFiltersList_success() throws CommandException, ParseException {
+        String validCommandModule = "find CS1101S";
+        assertCommandSuccess(validCommandModule, String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW,
+                model.getFilteredModuleList().size()), model);
+        assertEquals(logic.getFiltersList(), new ArrayList<>());
+
+        String validCommandPrefix = "find /m CS /g A";
+        assertCommandSuccess(validCommandPrefix, String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW,
+                model.getFilteredModuleList().size()), model);
+        List<String> filtersList = new ArrayList<>();
+        filtersList.add("/m CS");
+        filtersList.add("/g A");
+        assertEquals(logic.getFiltersList(), filtersList);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/modtrek/logic/LogicManagerTest.java
@@ -58,12 +58,14 @@ public class LogicManagerTest {
         String validCommandModule = "find CS1101S";
         assertCommandSuccess(validCommandModule, String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW,
                 model.getFilteredModuleList().size()), model);
-        assertEquals(logic.getFiltersList(), new ArrayList<>());
+        List<String> filtersList = new ArrayList<>();
+        filtersList.add("CS1101S");
+        assertEquals(logic.getFiltersList(), filtersList);
 
         String validCommandPrefix = "find /m CS /g A";
         assertCommandSuccess(validCommandPrefix, String.format(Messages.MESSAGE_MODULES_LISTED_OVERVIEW,
                 model.getFilteredModuleList().size()), model);
-        List<String> filtersList = new ArrayList<>();
+        filtersList.clear();
         filtersList.add("/m CS");
         filtersList.add("/g A");
         assertEquals(logic.getFiltersList(), filtersList);

--- a/src/test/java/seedu/modtrek/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/DeleteCommandTest.java
@@ -2,6 +2,7 @@ package seedu.modtrek.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.modtrek.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.modtrek.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
 import static seedu.modtrek.testutil.TypicalModules.CS2100;
@@ -32,42 +33,41 @@ class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(false, codesToDelete);
 
         String codesFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_SUCCESS, codesToDelete);
-        String codesNotFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_NOT_FOUND, new HashSet<>());
-        String expectedMessage = codesFound + "\n" + codesNotFound;
 
         ModelManager expectedModel = new ModelManager(model.getDegreeProgression(), new UserPrefs());
         expectedModel.deleteModule(moduleToDelete);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, model, codesFound, expectedModel);
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_success() {
+    public void execute_invalidIndexUnfilteredList_failure() {
         Set<Code> codesToDelete = new HashSet<>();
         codesToDelete.add(CS1101S.getCode());
         DeleteCommand deleteCommand = new DeleteCommand(false, codesToDelete);
 
-        String codesFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_SUCCESS, new HashSet<>());
         String codesNotFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_NOT_FOUND, codesToDelete);
-        String expectedMessage = codesFound + "\n" + codesNotFound;
 
-        ModelManager expectedModel = new ModelManager(model.getDegreeProgression(), new UserPrefs());
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(deleteCommand, model, codesNotFound);
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
+    public void execute_validAndInvalidIndexUnfilteredList_success() {
         Module moduleToDelete = model.getFilteredModuleList().get(0);
         Set<Code> codesToDelete = new HashSet<>();
         codesToDelete.add(CS2100.getCode());
+        codesToDelete.add(CS1101S.getCode());
         DeleteCommand deleteCommand = new DeleteCommand(false, codesToDelete);
 
+        codesToDelete.remove(CS1101S.getCode());
         String codesFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_SUCCESS, codesToDelete);
-        String codesNotFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_NOT_FOUND, new HashSet<>());
+        codesToDelete.remove(CS2100.getCode());
+        codesToDelete.add(CS1101S.getCode());
+        String codesNotFound = String.format(DeleteCommand.MESSAGE_DELETE_MODULE_NOT_FOUND, codesToDelete);
+        codesToDelete.add(CS2100.getCode());
         String expectedMessage = codesFound + "\n" + codesNotFound;
 
-        Model expectedModel = new ModelManager(model.getDegreeProgression(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getDegreeProgression(), new UserPrefs());
         expectedModel.deleteModule(moduleToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/modtrek/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/FindCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.modtrek.testutil.TypicalModules.CS2100;
 import static seedu.modtrek.testutil.TypicalModules.ST2334;
 import static seedu.modtrek.testutil.TypicalModules.getTypicalDegreeProgression;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
@@ -26,14 +27,14 @@ class FindCommandTest {
         ModuleCodePredicate secondPredicate =
                 new ModuleCodePredicate(ST2334.getCode().toString(), "", "", "", new HashSet<>());
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate, new ArrayList<>());
+        FindCommand findSecondCommand = new FindCommand(secondPredicate, new ArrayList<>());
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, new ArrayList<>());
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/modtrek/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/AddCommandParserTest.java
@@ -27,6 +27,7 @@ import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_CS1101S
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_MA2002;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_MA2002;
+import static seedu.modtrek.logic.parser.CliSyntax.*;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
@@ -44,7 +45,7 @@ import seedu.modtrek.model.tag.Tag;
 import seedu.modtrek.testutil.ModuleBuilder;
 
 public class AddCommandParserTest {
-    private AddCommandParser parser = new AddCommandParser();
+    private final AddCommandParser parser = new AddCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() {
@@ -92,24 +93,55 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_noArguments_failure() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_preamblePresent_failure() {
+        assertParseFailure(parser, " module"+ CODE_DESC_MA2002 + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
-        // missing name prefix
+        // missing code prefix
         assertParseFailure(parser, VALID_CODE_MA2002 + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002 + GRADE_DESC_MA2002,
-                expectedMessage);
+                AddCommand.MESSAGE_MISSING_PREFIXES);
 
-        // missing phone prefix
+        // missing credit prefix
         assertParseFailure(parser, CODE_DESC_MA2002 + VALID_CREDIT_MA2002 + SEMYEAR_DESC_MA2002 + GRADE_DESC_MA2002,
-                expectedMessage);
+                AddCommand.MESSAGE_MISSING_PREFIXES);
 
-        // missing email prefix
+        // missing sem-year prefix
         assertParseFailure(parser, CODE_DESC_MA2002 + CREDIT_DESC_MA2002 + VALID_SEMYEAR_MA2002 + GRADE_DESC_MA2002,
-                expectedMessage);
+                AddCommand.MESSAGE_MISSING_PREFIXES);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_CODE_MA2002 + VALID_CREDIT_MA2002 + VALID_SEMYEAR_MA2002 + VALID_GRADE_MA2002,
-                expectedMessage);
+                AddCommand.MESSAGE_MISSING_PREFIXES);
+    }
+
+    @Test
+    public void parse_detailMissing_failure() {
+
+        // missing code detail
+        assertParseFailure(parser, " " + PREFIX_CODE + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002
+                        + GRADE_DESC_MA2002, Code.MESSAGE_MISSING_DETAIL);
+
+        // missing credit detail
+        assertParseFailure(parser, CODE_DESC_MA2002 + " " + PREFIX_CREDIT + SEMYEAR_DESC_MA2002
+                        + GRADE_DESC_MA2002, Credit.MESSAGE_MISSING_DETAIL);
+
+        // missing sem-year detail
+        assertParseFailure(parser, CODE_DESC_MA2002 + CREDIT_DESC_MA2002 + " " + PREFIX_SEMYEAR
+                        + GRADE_DESC_MA2002, SemYear.MESSAGE_MISSING_DETAIL);
+
+        // missing tag detail
+        assertParseFailure(parser, CODE_DESC_MA2002 + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002
+                        + " " + PREFIX_TAG, Tag.MESSAGE_MISSING_DETAIL);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/AddCommandParserTest.java
@@ -27,7 +27,10 @@ import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_CS1101S
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_MA2002;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_MA2002;
-import static seedu.modtrek.logic.parser.CliSyntax.*;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CREDIT;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_SEMYEAR;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
@@ -100,7 +103,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_preamblePresent_failure() {
-        assertParseFailure(parser, " module"+ CODE_DESC_MA2002 + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002,
+        assertParseFailure(parser, " module" + CODE_DESC_MA2002 + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/modtrek/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.modtrek.logic.parser;
 
 import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.modtrek.logic.commands.CommandTestUtil.CODE_DESC_CS1101S;
+import static seedu.modtrek.logic.commands.CommandTestUtil.CODE_DESC_MA2002;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
@@ -23,13 +26,13 @@ import seedu.modtrek.model.module.Code;
  */
 public class DeleteCommandParserTest {
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private final DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         Set<Code> codesToDelete = new HashSet<>();
         codesToDelete.add(CS1101S.getCode());
-        assertParseSuccess(parser, " /m CS1101S", new DeleteCommand(false, codesToDelete));
+        assertParseSuccess(parser, CODE_DESC_CS1101S, new DeleteCommand(false, codesToDelete));
     }
 
     @Test
@@ -37,13 +40,18 @@ public class DeleteCommandParserTest {
         Set<Code> codesToDelete = new HashSet<>();
         codesToDelete.add(CS1101S.getCode());
         codesToDelete.add(MA2002.getCode());
-        assertParseSuccess(parser, " /m CS1101S /m MA2002", new DeleteCommand(false, codesToDelete));
+        assertParseSuccess(parser, CODE_DESC_CS1101S + CODE_DESC_MA2002, new DeleteCommand(false, codesToDelete));
     }
 
     @Test
     public void parse_validArgsAll_returnsDeleteCommand() {
         Set<Code> codesToDelete = new HashSet<>();
         assertParseSuccess(parser, "all", new DeleteCommand(true, codesToDelete));
+    }
+
+    @Test
+    public void parse_detailMissing_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_CODE, Code.MESSAGE_MISSING_DETAIL);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
@@ -24,8 +24,7 @@ import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_CS1101S
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_MA2002;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_MA2002;
-import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
-import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.modtrek.logic.parser.CliSyntax.*;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
@@ -48,15 +47,15 @@ class EditCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
-    private EditCommandParser parser = new EditCommandParser();
+    private final EditCommandParser parser = new EditCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
         // no module specified
-        assertParseFailure(parser, PREFIX_CODE + " " + VALID_CODE_CS1101S, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " " + PREFIX_CODE + " " + VALID_CODE_CS1101S, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, VALID_CODE_CS1101S, EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S, EditCommand.MESSAGE_NOT_EDITED);
 
         // no module and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -65,30 +64,30 @@ class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, VALID_CODE_CS1101S + VALID_CREDIT_CS1101S, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S + VALID_CREDIT_CS1101S, Code.MESSAGE_CONSTRAINTS);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, VALID_CODE_CS1101S + "/i " + VALID_CREDIT_CS1101S, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S + "/i " + VALID_CREDIT_CS1101S, Code.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, VALID_CODE_CS1101S + INVALID_CODE_DESC,
-                Code.MESSAGE_CONSTRAINTS); // invalid name
+                Code.MESSAGE_CONSTRAINTS); // invalid code
         assertParseFailure(parser, VALID_CODE_CS1101S + INVALID_CREDIT_DESC,
-                Credit.MESSAGE_CONSTRAINTS); // invalid phone
+                Credit.MESSAGE_CONSTRAINTS); // invalid credit
         assertParseFailure(parser, VALID_CODE_CS1101S + INVALID_SEMYEAR_DESC,
-                SemYear.MESSAGE_CONSTRAINTS); // invalid email
+                SemYear.MESSAGE_CONSTRAINTS); // invalid sem-year
         assertParseFailure(parser, VALID_CODE_CS1101S + INVALID_GRADE_DESC,
-                Grade.MESSAGE_CONSTRAINTS); // invalid address
+                Grade.MESSAGE_CONSTRAINTS); // invalid grade
         assertParseFailure(parser, VALID_CODE_CS1101S + INVALID_TAG_DESC,
                 Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
-        // invalid phone followed by valid email
+        // invalid credit followed by valid sem-year
         assertParseFailure(parser, VALID_CODE_CS1101S + INVALID_CREDIT_DESC
                 + SEMYEAR_DESC_CS1101S, Credit.MESSAGE_CONSTRAINTS);
 
-        // valid phone followed by invalid phone. The test case for invalid phone followed by valid phone
+        // valid credit followed by invalid credit. The test case for invalid credit followed by valid credit
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, VALID_CODE_CS1101S + CREDIT_DESC_MA2002
                 + INVALID_CREDIT_DESC, Credit.MESSAGE_CONSTRAINTS);
@@ -109,8 +108,17 @@ class EditCommandParserTest {
     }
 
     @Test
+    public void parse_missingValue_failure() {
+        assertParseFailure(parser, VALID_CODE_CS1101S + " " + PREFIX_CODE,
+                Code.MESSAGE_MISSING_DETAIL);
+        assertParseFailure(parser, VALID_CODE_CS1101S + " " + PREFIX_CREDIT,
+                Credit.MESSAGE_MISSING_DETAIL);
+        assertParseFailure(parser, VALID_CODE_CS1101S + " " + PREFIX_SEMYEAR,
+                SemYear.MESSAGE_MISSING_DETAIL);
+    }
+
+    @Test
     public void parse_allFieldsSpecified_success() {
-        Module targetModule = CS1101S;
         String userInput = VALID_CODE_CS1101S + CREDIT_DESC_MA2002 + TAG_DESC_CS1101S
                 + SEMYEAR_DESC_CS1101S + GRADE_DESC_CS1101S + CODE_DESC_CS1101S + TAG_DESC_MA2002;
 
@@ -126,7 +134,6 @@ class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Module targetModule = CS1101S;
         String userInput = VALID_CODE_CS1101S + CREDIT_DESC_MA2002 + SEMYEAR_DESC_CS1101S;
 
         EditCommand.EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder()
@@ -139,27 +146,26 @@ class EditCommandParserTest {
 
     @Test
     public void parse_oneFieldSpecified_success() {
-        // name
-        Module targetModule = CS1101S;
+        // code
         String userInput = VALID_CODE_CS1101S + CODE_DESC_CS1101S;
         EditCommand.EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder()
                 .withCode(VALID_CODE_CS1101S).build();
         EditCommand expectedCommand = new EditCommand(new Code(VALID_CODE_CS1101S), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // phone
+        // credit
         userInput = VALID_CODE_CS1101S + CREDIT_DESC_CS1101S;
         descriptor = new EditModuleDescriptorBuilder().withCredit(VALID_CREDIT_CS1101S).build();
         expectedCommand = new EditCommand(new Code(VALID_CODE_CS1101S), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // email
+        // sem-year
         userInput = VALID_CODE_CS1101S + SEMYEAR_DESC_CS1101S;
         descriptor = new EditModuleDescriptorBuilder().withSemYear(VALID_SEMYEAR_CS1101S).build();
         expectedCommand = new EditCommand(new Code(VALID_CODE_CS1101S), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // address
+        // grade
         userInput = VALID_CODE_CS1101S + GRADE_DESC_CS1101S;
         descriptor = new EditModuleDescriptorBuilder().withGrade(VALID_GRADE_CS1101S).build();
         expectedCommand = new EditCommand(new Code(VALID_CODE_CS1101S), descriptor);
@@ -174,7 +180,6 @@ class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Module targetModule = CS1101S;
         String userInput = VALID_CODE_CS1101S + CREDIT_DESC_CS1101S + GRADE_DESC_CS1101S
                 + SEMYEAR_DESC_CS1101S
                 + TAG_DESC_MA2002 + CREDIT_DESC_CS1101S + GRADE_DESC_CS1101S + SEMYEAR_DESC_CS1101S
@@ -194,7 +199,6 @@ class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Module targetModule = CS1101S;
         String userInput = VALID_CODE_CS1101S + INVALID_CREDIT_DESC + CREDIT_DESC_MA2002;
         EditCommand.EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder()
                 .withCredit(VALID_CREDIT_MA2002).build();
@@ -209,18 +213,6 @@ class EditCommandParserTest {
                 .withSemYear(VALID_SEMYEAR_MA2002)
                 .withGrade(VALID_GRADE_MA2002).build();
         expectedCommand = new EditCommand(new Code(VALID_CODE_CS1101S), descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
-    }
-
-    @Test
-    public void parse_resetTags_success() {
-        Module targetModule = CS1101S;
-        String userInput = VALID_CODE_CS1101S + TAG_EMPTY;
-
-        EditCommand.EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder()
-                .withTags().build();
-        EditCommand expectedCommand = new EditCommand(new Code(VALID_CODE_CS1101S), descriptor);
-
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
@@ -24,10 +24,12 @@ import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_CS1101S
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_SEMYEAR_MA2002;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_MA2002;
-import static seedu.modtrek.logic.parser.CliSyntax.*;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CREDIT;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_SEMYEAR;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.modtrek.testutil.TypicalModules.CS1101S;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +37,6 @@ import seedu.modtrek.logic.commands.EditCommand;
 import seedu.modtrek.model.module.Code;
 import seedu.modtrek.model.module.Credit;
 import seedu.modtrek.model.module.Grade;
-import seedu.modtrek.model.module.Module;
 import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.model.tag.Tag;
 import seedu.modtrek.testutil.EditModuleDescriptorBuilder;

--- a/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
@@ -14,7 +14,9 @@ import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -66,15 +68,17 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new ModuleCodePredicate("CS1101S",
-                        "", "", "", new HashSet<>()));
+                        "", "", "", new HashSet<>()), new ArrayList<>());
         assertParseSuccess(parser, "CS1101S", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgsModuleCodePrefix_returnsFindCommand() {
+        List<String> filtersList = new ArrayList<>();
+        filtersList.add("/m CS");
         FindCommand expectedFindCommand =
                 new FindCommand(new ModuleCodePredicate("CS",
-                        "", "", "", new HashSet<>()));
+                        "", "", "", new HashSet<>()), filtersList);
         assertParseSuccess(parser, CODEPREFIX_DESC_CS, expectedFindCommand);
     }
 
@@ -82,8 +86,14 @@ public class FindCommandParserTest {
     public void parse_validArgsAllPrefix_returnsFindCommand() {
         HashSet<Tag> tags = new HashSet<>();
         tags.add(new Tag("Computer Science Foundation"));
+        List<String> filtersList = new ArrayList<>();
+        filtersList.add("/m CS");
+        filtersList.add("/c 4");
+        filtersList.add("/y Y1S1");
+        filtersList.add("/g A");
+        filtersList.add("/t CSF");
         FindCommand expectedFindCommand =
-                new FindCommand(new ModuleCodePredicate("CS", "4", "Y1S1", "A", tags));
+                new FindCommand(new ModuleCodePredicate("CS", "4", "Y1S1", "A", tags), filtersList);
         assertParseSuccess(parser, CODEPREFIX_DESC_CS + CREDIT_DESC_CS1101S
                 + SEMYEAR_DESC_CS1101S + GRADE_DESC_CS1101S + TAG_DESC_CS1101S, expectedFindCommand);
     }

--- a/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.modtrek.logic.commands.CommandTestUtil.CREDIT_DESC_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.GRADE_DESC_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.SEMYEAR_DESC_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.TAG_DESC_CS1101S;
+import static seedu.modtrek.logic.parser.CliSyntax.*;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -14,42 +15,42 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.FindCommand;
-import seedu.modtrek.model.module.ModuleCodePredicate;
+import seedu.modtrek.model.module.*;
 import seedu.modtrek.model.tag.Tag;
 
 public class FindCommandParserTest {
 
-    private FindCommandParser parser = new FindCommandParser();
+    private final FindCommandParser parser = new FindCommandParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ",
+        assertParseFailure(parser, "",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_emptyArgAfterPrefixCode_throwsParseException() {
-        assertParseFailure(parser, " /m", "Missing module code prefix after /m");
+        assertParseFailure(parser, " " + PREFIX_CODE, CodePrefix.MESSAGE_MISSING_DETAIL);
     }
 
     @Test
     public void parse_emptyArgAfterPrefixCredit_throwsParseException() {
-        assertParseFailure(parser, " /c", "Missing credit after /c");
+        assertParseFailure(parser, " " + PREFIX_CREDIT, Credit.MESSAGE_MISSING_DETAIL);
     }
 
     @Test
     public void parse_emptyArgAfterPrefixSemYear_throwsParseException() {
-        assertParseFailure(parser, " /y", "Missing semyear after /y");
+        assertParseFailure(parser, " " + PREFIX_SEMYEAR, SemYear.MESSAGE_MISSING_DETAIL);
     }
 
     @Test
     public void parse_emptyArgAfterPrefixGrade_throwsParseException() {
-        assertParseFailure(parser, " /g", "Missing grade after /g");
+        assertParseFailure(parser, " " + PREFIX_GRADE, Grade.MESSAGE_MISSING_DETAIL);
     }
 
     @Test
     public void parse_emptyArgAfterPrefixTag_throwsParseException() {
-        assertParseFailure(parser, " /t", "Missing tag after /t");
+        assertParseFailure(parser, " " + PREFIX_TAG, Tag.MESSAGE_MISSING_DETAIL);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
@@ -6,7 +6,11 @@ import static seedu.modtrek.logic.commands.CommandTestUtil.CREDIT_DESC_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.GRADE_DESC_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.SEMYEAR_DESC_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.TAG_DESC_CS1101S;
-import static seedu.modtrek.logic.parser.CliSyntax.*;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_CREDIT;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_GRADE;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_SEMYEAR;
+import static seedu.modtrek.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -15,7 +19,11 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.FindCommand;
-import seedu.modtrek.model.module.*;
+import seedu.modtrek.model.module.CodePrefix;
+import seedu.modtrek.model.module.Credit;
+import seedu.modtrek.model.module.Grade;
+import seedu.modtrek.model.module.ModuleCodePredicate;
+import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.model.tag.Tag;
 
 public class FindCommandParserTest {

--- a/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
@@ -12,11 +12,11 @@ import seedu.modtrek.logic.commands.EditCommand;
 import seedu.modtrek.logic.commands.ExitCommand;
 import seedu.modtrek.logic.commands.FindCommand;
 import seedu.modtrek.logic.commands.HelpCommand;
-import seedu.modtrek.logic.commands.ListCommand;
 import seedu.modtrek.logic.commands.TagCommand;
+import seedu.modtrek.logic.commands.ViewCommand;
 
 public class HelpCommandParserTest {
-    private HelpCommandParser parser = new HelpCommandParser();
+    private final HelpCommandParser parser = new HelpCommandParser();
 
     @Test
     public void parse_helpNoArgs_success() {
@@ -44,8 +44,8 @@ public class HelpCommandParserTest {
     }
 
     @Test
-    public void parse_helpList_success() {
-        assertParseSuccess(parser, "list", new HelpCommand(ListCommand.MESSAGE_USAGE));
+    public void parse_helpView_success() {
+        assertParseSuccess(parser, "view", new HelpCommand(ViewCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
@@ -7,6 +7,7 @@ import static seedu.modtrek.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.modtrek.testutil.Assert.assertThrows;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -74,7 +75,8 @@ public class ModTrekParserTest {
     public void parseCommand_find() throws Exception {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + "CS1101S");
-        assertEquals(new FindCommand(new ModuleCodePredicate("CS1101S", "", "", "", new HashSet<>())), command);
+        assertEquals(new FindCommand(new ModuleCodePredicate(
+                "CS1101S", "", "", "", new HashSet<>()), new ArrayList<>()), command);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/TagCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.modtrek.logic.parser;
 
+import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_CODE_CS1101S;
 import static seedu.modtrek.logic.commands.CommandTestUtil.VALID_TAG_CS1101S;
@@ -13,7 +14,6 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.TagCommand;
-import seedu.modtrek.model.module.Code;
 import seedu.modtrek.model.tag.Tag;
 
 class TagCommandParserTest {
@@ -23,18 +23,19 @@ class TagCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no module specified
-        assertParseFailure(parser, PREFIX_TAG + "Computer Science Foundation", Code.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, PREFIX_TAG + "Computer Science Foundation",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, VALID_CODE_CS1101S + "Computer Science Foundation",
-                Code.MESSAGE_CONSTRAINTS);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, VALID_CODE_CS1101S + "/i " + "Computer Science Foundation",
-                Code.MESSAGE_CONSTRAINTS);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -48,17 +49,25 @@ class TagCommandParserTest {
     @Test
     public void parse_missingPrefix_failure() {
         assertParseFailure(parser, VALID_CODE_CS1101S + " include",
-                "Did not specify prefix /t");
+                TagCommand.MESSAGE_MISSING_PREFIX);
         assertParseFailure(parser, VALID_CODE_CS1101S + " remove",
-                "Did not specify prefix /t");
+                TagCommand.MESSAGE_MISSING_PREFIX);
+    }
+
+    @Test
+    public void parse_missingTagDetails_failure() {
+        assertParseFailure(parser, VALID_CODE_CS1101S + " include " + PREFIX_TAG,
+                Tag.MESSAGE_MISSING_DETAIL);
+        assertParseFailure(parser, VALID_CODE_CS1101S + " remove " + PREFIX_TAG,
+                Tag.MESSAGE_MISSING_DETAIL);
     }
 
     @Test
     public void parse_missingIncludeRemove_failure() {
         assertParseFailure(parser, VALID_CODE_CS1101S,
-                "Did not specify whether to include or remove tags");
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         assertParseFailure(parser, VALID_CODE_CS1101S,
-                "Did not specify whether to include or remove tags");
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
- Handled edge cases of error, for example "missing prefix" or "missing detail after prefix"
- Generally standardised error handling across each Parser class
- Prettified the output of response messages to make them more readable and user-friendly
- Help command has been updated accordingly:
i. `help` now displays a list of help commands for users to refer to individually, instead of outputting the entire list of format commands which clogs the CLI section of the GUI.
ii. Replaced `help list` with `help view` since the list command will be replaced with the view modules command.
- The handling of Delete command has been updated accordingly:
i. If all modules listed are not found in the user's storage, an error will be thrown outputting the modules not found.
ii. If all modules listed are found in the user's storage, a correct output is shown listing the modules which have been deleted.
iii. Out of all listed modules to be deleted, if there exists module(s) found and not found in the user's storage, a correct output is shown listing both the modules which have been deleted, as well as, the modules not found.
- Added getter method for list of filters for find command to LogicManager class, for integration into Module Search part of GUI handed to @jmestxr 

Additional Notes:
- Once find and sort commands are refined, need to update this again.
- The List and Clear commands and their dependency classes can be deleted in a future PR.