### PR TITLE
Find command enhancement: Allow for multiple prefixes filtering

### DIFF
--- a/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/FindCommandParser.java
@@ -46,64 +46,60 @@ public class FindCommandParser implements Parser<FindCommand> {
         List<String> filtersList = new ArrayList<>();
 
         boolean isModulePrefixPresent = argMultimap.getValue(PREFIX_CODE).isPresent();
-        String codePrefixString = argMultimap.getValue(PREFIX_CODE).orElse("");
-        if (isModulePrefixPresent && codePrefixString.isEmpty()) {
+        if (isModulePrefixPresent && argMultimap.getAllValues(PREFIX_CODE).contains("")) {
             throw new ParseException(CodePrefix.MESSAGE_MISSING_DETAIL);
         }
-        if (!codePrefixString.isEmpty()) {
-            codePrefixString = ParserUtil.parseCodePrefix(codePrefixString).toString();
-            filtersList.add(PREFIX_CODE + " " + codePrefixString);
+        Set<String> codePrefixSet = ParserUtil.parseCodePrefixes(argMultimap.getAllValues(PREFIX_CODE));
+        for (String codePrefix : codePrefixSet) {
+            filtersList.add(PREFIX_CODE + " " + codePrefix);
         }
 
         boolean isCreditPrefixPresent = argMultimap.getValue(PREFIX_CREDIT).isPresent();
-        String creditString = argMultimap.getValue(PREFIX_CREDIT).orElse("");
-        if (isCreditPrefixPresent && creditString.isEmpty()) {
+        if (isCreditPrefixPresent && argMultimap.getAllValues(PREFIX_CREDIT).contains("")) {
             throw new ParseException(Credit.MESSAGE_MISSING_DETAIL);
         }
-        if (!creditString.isEmpty()) {
-            creditString = ParserUtil.parseCredit(creditString).toString();
-            filtersList.add(PREFIX_CREDIT + " " + creditString);
+        Set<Credit> creditSet = ParserUtil.parseCredits(argMultimap.getAllValues(PREFIX_CREDIT));
+        for (Credit credit : creditSet) {
+            filtersList.add(PREFIX_CREDIT + " " + credit.toString());
         }
 
         boolean isSemYearPresent = argMultimap.getValue(PREFIX_SEMYEAR).isPresent();
-        String semYearString = argMultimap.getValue(PREFIX_SEMYEAR).orElse("");
-        if (isSemYearPresent && semYearString.isEmpty()) {
+        if (isSemYearPresent && argMultimap.getAllValues(PREFIX_SEMYEAR).contains("")) {
             throw new ParseException(SemYear.MESSAGE_MISSING_DETAIL);
         }
-        if (!semYearString.isEmpty()) {
-            semYearString = ParserUtil.parseSemYear(semYearString).toString();
-            filtersList.add(PREFIX_SEMYEAR + " " + semYearString);
+        Set<SemYear> semYearSet = ParserUtil.parseSemYears(argMultimap.getAllValues(PREFIX_SEMYEAR));
+        for (SemYear semYear : semYearSet) {
+            filtersList.add(PREFIX_SEMYEAR + " " + semYear.toString());
         }
 
         boolean isGradePresent = argMultimap.getValue(PREFIX_GRADE).isPresent();
-        String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
-        if (isGradePresent && gradeString.isEmpty()) {
+        if (isGradePresent && argMultimap.getAllValues(PREFIX_GRADE).contains("")) {
             throw new ParseException(Grade.MESSAGE_MISSING_DETAIL);
         }
-        if (!gradeString.isEmpty()) {
-            gradeString = ParserUtil.parseGrade(gradeString).toString();
-            filtersList.add(PREFIX_GRADE + " " + gradeString);
+        Set<Grade> gradeSet = ParserUtil.parseGrades(argMultimap.getAllValues(PREFIX_GRADE));
+        for (Grade grade : gradeSet) {
+            filtersList.add(PREFIX_GRADE + " " + grade.toString());
         }
 
         boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
         if (isTagPresent && argMultimap.getAllValues(PREFIX_TAG).contains("")) {
             throw new ParseException(Tag.MESSAGE_MISSING_DETAIL);
         }
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        for (Tag tag : tagList) {
+        Set<Tag> tagSet = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        for (Tag tag : tagSet) {
             filtersList.add(PREFIX_TAG + " " + tag.tagName);
         }
 
         ModuleCodePredicate moduleCodePredicate;
         if (!argMultimap.getPreamble().isEmpty()) {
             Code code = ParserUtil.parseCode(argMultimap.getPreamble());
-            moduleCodePredicate = new ModuleCodePredicate(code.toString(), "",
-                    "", "", new HashSet<>());
+            moduleCodePredicate = new ModuleCodePredicate(true, code.toString(), new HashSet<>(),
+                    new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>());
             filtersList.clear();
             filtersList.add(code.toString());
         } else {
-            moduleCodePredicate = new ModuleCodePredicate(codePrefixString, creditString,
-                    semYearString, gradeString, (HashSet<Tag>) tagList);
+            moduleCodePredicate = new ModuleCodePredicate(false, "", codePrefixSet,
+                    creditSet, semYearSet, gradeSet, tagSet);
         }
 
         return new FindCommand(moduleCodePredicate, filtersList);

--- a/src/main/java/seedu/modtrek/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/modtrek/logic/parser/ParserUtil.java
@@ -53,6 +53,18 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code Collection<String> codePrefixes} into a {@code Set<String>}.
+     */
+    public static Set<String> parseCodePrefixes(Collection<String> codePrefixes) throws ParseException {
+        requireNonNull(codePrefixes);
+        final Set<String> codePrefixSet = new HashSet<>();
+        for (String codePrefixName : codePrefixes) {
+            codePrefixSet.add(parseCodePrefix(codePrefixName).toString());
+        }
+        return codePrefixSet;
+    }
+
+    /**
      * Parses a {@code String credit} into a {@code Credit}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -65,6 +77,18 @@ public class ParserUtil {
             throw new ParseException(Credit.MESSAGE_CONSTRAINTS);
         }
         return new Credit(trimmedCredit);
+    }
+
+    /**
+     * Parses {@code Collection<String> credits} into a {@code Set<Credit>}.
+     */
+    public static Set<Credit> parseCredits(Collection<String> credits) throws ParseException {
+        requireNonNull(credits);
+        final Set<Credit> creditSet = new HashSet<>();
+        for (String creditName : credits) {
+            creditSet.add(parseCredit(creditName));
+        }
+        return creditSet;
     }
 
     /**
@@ -83,6 +107,18 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code Collection<String> semYears} into a {@code Set<SemYear>}.
+     */
+    public static Set<SemYear> parseSemYears(Collection<String> semYears) throws ParseException {
+        requireNonNull(semYears);
+        final Set<SemYear> semYearSet = new HashSet<>();
+        for (String semYearName : semYears) {
+            semYearSet.add(parseSemYear(semYearName));
+        }
+        return semYearSet;
+    }
+
+    /**
      * Parses a {@code String grade} into an {@code Grade}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -95,6 +131,18 @@ public class ParserUtil {
             throw new ParseException(Grade.MESSAGE_CONSTRAINTS);
         }
         return new Grade(trimmedGrade);
+    }
+
+    /**
+     * Parses {@code Collection<String> grades} into a {@code Set<Grade>}.
+     */
+    public static Set<Grade> parseGrades(Collection<String> grades) throws ParseException {
+        requireNonNull(grades);
+        final Set<Grade> gradeSet = new HashSet<>();
+        for (String gradeName : grades) {
+            gradeSet.add(parseGrade(gradeName));
+        }
+        return gradeSet;
     }
 
     /**

--- a/src/main/java/seedu/modtrek/model/module/ModuleCodePredicate.java
+++ b/src/main/java/seedu/modtrek/model/module/ModuleCodePredicate.java
@@ -1,6 +1,6 @@
 package seedu.modtrek.model.module;
 
-import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.modtrek.model.tag.Tag;
@@ -9,35 +9,60 @@ import seedu.modtrek.model.tag.Tag;
  * Tests that a {@code Module}'s {@code Name} matches module code.
  */
 public class ModuleCodePredicate implements Predicate<Module> {
+    private final boolean isCode;
     private final String moduleCode;
-    private final String credit;
-    private final String semYear;
-    private final String grade;
-    private final HashSet<Tag> tags;
+    private final Set<String> codePrefixes;
+    private final Set<Credit> credits;
+    private final Set<SemYear> semYears;
+    private final Set<Grade> grades;
+    private final Set<Tag> tags;
 
     /**
      * Instantiates a new ModulePredicate.
-     * @param moduleCode either the code prefix or the entire code
-     * @param credit     the credit
-     * @param semYear    the semester year
-     * @param grade      the grade
-     * @param tags       the tags
+     * @param isCode       whether to filter code or code prefix
+     * @param moduleCode   the entire module code
+     * @param codePrefixes the set of code prefixes
+     * @param credits      the set of credits
+     * @param semYears     the set semester-years
+     * @param grades       the set of grades
+     * @param tags         the set of tags
      */
-    public ModuleCodePredicate(String moduleCode, String credit, String semYear, String grade, HashSet<Tag> tags) {
+    public ModuleCodePredicate(boolean isCode, String moduleCode, Set<String> codePrefixes,
+                               Set<Credit> credits, Set<SemYear> semYears, Set<Grade> grades, Set<Tag> tags) {
+        this.isCode = isCode;
+        this.codePrefixes = codePrefixes;
         this.moduleCode = moduleCode;
-        this.credit = credit;
-        this.semYear = semYear;
-        this.grade = grade;
+        this.credits = credits;
+        this.semYears = semYears;
+        this.grades = grades;
         this.tags = tags;
     }
 
     @Override
     public boolean test(Module module) {
-        return (moduleCode.isEmpty() || module.getCode().toString().startsWith(moduleCode))
-                && (credit.isEmpty() || module.getCredit().equals(new Credit(credit)))
-                && (semYear.isEmpty() || module.getSemYear().equals(new SemYear(semYear)))
-                && (grade.isEmpty() || module.getGrade().equals(new Grade(grade)))
+        if (isCode) {
+            return module.getCode().toString().equals(moduleCode);
+        }
+        return (codePrefixes.isEmpty() || startsWithAnyPrefix(codePrefixes, module.getCode().toString()))
+                && (credits.isEmpty() || credits.contains(module.getCredit()))
+                && (semYears.isEmpty() || semYears.contains(module.getSemYear()))
+                && (grades.isEmpty() || grades.contains(module.getGrade()))
                 && (tags.isEmpty() || module.getTags().containsAll(tags));
+    }
+
+    /**
+     * Checks if each module code starts with any of the code prefixes in the set.
+     * @param codePrefixSet the set of code prefixes to be filtered
+     * @param moduleCode    the module code
+     * @return true if the module code starts with any of the code prefixes in the set, false otherwise
+     */
+    public boolean startsWithAnyPrefix(Set<String> codePrefixSet, String moduleCode) {
+        for (String prefix : codePrefixSet) {
+            if (moduleCode.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -45,9 +70,9 @@ public class ModuleCodePredicate implements Predicate<Module> {
         return other == this // short circuit if same object
                 || (other instanceof ModuleCodePredicate // instanceof handles nulls
                 && moduleCode.equals(((ModuleCodePredicate) other).moduleCode) // state check
-                && credit.equals(((ModuleCodePredicate) other).credit)
-                && semYear.equals(((ModuleCodePredicate) other).semYear)
-                && grade.equals(((ModuleCodePredicate) other).grade)
+                && credits.equals(((ModuleCodePredicate) other).credits)
+                && semYears.equals(((ModuleCodePredicate) other).semYears)
+                && grades.equals(((ModuleCodePredicate) other).grades)
                 && tags.equals(((ModuleCodePredicate) other).tags));
     }
 

--- a/src/main/java/seedu/modtrek/model/module/SemYear.java
+++ b/src/main/java/seedu/modtrek/model/module/SemYear.java
@@ -9,7 +9,8 @@ import static seedu.modtrek.commons.util.AppUtil.checkArgument;
 public class SemYear {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "SemYear should be alphanumeric in the format YxS(T)x, where x are digits.";
+            "SemYear should be alphanumeric in the format YxS(T)x, where the first x is a digit between 0 and 5,"
+                    + " and the second x is a digit between 1 and 2.";
 
     public static final String MESSAGE_MISSING_DETAIL = "Missing sem-year after /y.";
 

--- a/src/test/java/seedu/modtrek/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/FindCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.modtrek.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.modtrek.testutil.TypicalModules.CS2100;
 import static seedu.modtrek.testutil.TypicalModules.ST2334;
 import static seedu.modtrek.testutil.TypicalModules.getTypicalDegreeProgression;
@@ -17,34 +17,36 @@ import seedu.modtrek.model.UserPrefs;
 import seedu.modtrek.model.module.ModuleCodePredicate;
 
 class FindCommandTest {
-    private Model model = new ModelManager(getTypicalDegreeProgression(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalDegreeProgression(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalDegreeProgression(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalDegreeProgression(), new UserPrefs());
 
     @Test
     public void equals() {
         ModuleCodePredicate firstPredicate =
-                new ModuleCodePredicate(CS2100.getCode().toString(), "", "", "", new HashSet<>());
+                new ModuleCodePredicate(true, CS2100.getCode().toString(), new HashSet<>(),
+                        new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>());
         ModuleCodePredicate secondPredicate =
-                new ModuleCodePredicate(ST2334.getCode().toString(), "", "", "", new HashSet<>());
+                new ModuleCodePredicate(true, ST2334.getCode().toString(), new HashSet<>(),
+                        new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>());
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate, new ArrayList<>());
         FindCommand findSecondCommand = new FindCommand(secondPredicate, new ArrayList<>());
 
         // same object -> returns true
-        assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertEquals(findFirstCommand, findFirstCommand);
 
         // same values -> returns true
         FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, new ArrayList<>());
-        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+        assertEquals(findFirstCommand, findFirstCommandCopy);
 
         // different types -> returns false
-        assertFalse(findFirstCommand.equals(1));
+        assertNotEquals(1, findFirstCommand);
 
         // null -> returns false
-        assertFalse(findFirstCommand.equals(null));
+        assertNotEquals(null, findFirstCommand);
 
         // different person -> returns false
-        assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertNotEquals(findFirstCommand, findSecondCommand);
     }
 
 }

--- a/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
@@ -67,23 +67,33 @@ public class FindCommandParserTest {
     public void parse_validArgsModuleCode_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new ModuleCodePredicate("CS1101S",
-                        "", "", "", new HashSet<>()), new ArrayList<>());
+                new FindCommand(new ModuleCodePredicate(true, "CS1101S", new HashSet<>(),
+                        new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>()), new ArrayList<>());
         assertParseSuccess(parser, "CS1101S", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgsModuleCodePrefix_returnsFindCommand() {
+        HashSet<String> codePrefixes = new HashSet<>();
+        codePrefixes.add("CS");
         List<String> filtersList = new ArrayList<>();
         filtersList.add("/m CS");
         FindCommand expectedFindCommand =
-                new FindCommand(new ModuleCodePredicate("CS",
-                        "", "", "", new HashSet<>()), filtersList);
+                new FindCommand(new ModuleCodePredicate(false, "", codePrefixes,
+                        new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>()), filtersList);
         assertParseSuccess(parser, CODEPREFIX_DESC_CS, expectedFindCommand);
     }
 
     @Test
     public void parse_validArgsAllPrefix_returnsFindCommand() {
+        HashSet<String> codePrefixes = new HashSet<>();
+        codePrefixes.add("CS");
+        HashSet<Credit> credits = new HashSet<>();
+        credits.add(new Credit("4"));
+        HashSet<SemYear> semYears = new HashSet<>();
+        semYears.add(new SemYear("Y1S1"));
+        HashSet<Grade> grades = new HashSet<>();
+        grades.add(new Grade("A"));
         HashSet<Tag> tags = new HashSet<>();
         tags.add(new Tag("Computer Science Foundation"));
         List<String> filtersList = new ArrayList<>();
@@ -93,7 +103,8 @@ public class FindCommandParserTest {
         filtersList.add("/g A");
         filtersList.add("/t CSF");
         FindCommand expectedFindCommand =
-                new FindCommand(new ModuleCodePredicate("CS", "4", "Y1S1", "A", tags), filtersList);
+                new FindCommand(new ModuleCodePredicate(false, "",
+                        codePrefixes, credits, semYears, grades, tags), filtersList);
         assertParseSuccess(parser, CODEPREFIX_DESC_CS + CREDIT_DESC_CS1101S
                 + SEMYEAR_DESC_CS1101S + GRADE_DESC_CS1101S + TAG_DESC_CS1101S, expectedFindCommand);
     }

--- a/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
@@ -75,8 +75,9 @@ public class ModTrekParserTest {
     public void parseCommand_find() throws Exception {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + "CS1101S");
-        assertEquals(new FindCommand(new ModuleCodePredicate(
-                "CS1101S", "", "", "", new HashSet<>()), new ArrayList<>()), command);
+        assertEquals(new FindCommand(new ModuleCodePredicate(true,
+                "CS1101S", new HashSet<>(), new HashSet<>(),
+                new HashSet<>(), new HashSet<>(), new HashSet<>()), new ArrayList<>()), command);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/model/module/ModuleCodePredicateTest.java
+++ b/src/test/java/seedu/modtrek/model/module/ModuleCodePredicateTest.java
@@ -1,7 +1,8 @@
 package seedu.modtrek.model.module;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
 import static seedu.modtrek.testutil.TypicalModules.ST2334;
 
@@ -16,42 +17,56 @@ class ModuleCodePredicateTest {
 
     @Test
     public void equals() {
-        ModuleCodePredicate firstPredicate = new ModuleCodePredicate(CS1101S.getCode().toString(),
-                "", "", "", new HashSet<>());
+        ModuleCodePredicate firstPredicate = new ModuleCodePredicate(true, CS1101S.getCode().toString(),
+                new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>());
+
+        HashSet<Credit> credits = new HashSet<>();
+        credits.add(new Credit("4"));
+        HashSet<SemYear> semYears = new HashSet<>();
+        semYears.add(new SemYear("Y2S1"));
+        HashSet<Grade> grades = new HashSet<>();
+        grades.add(new Grade("A"));
         HashSet<Tag> tags = new HashSet<>();
         tags.add(new Tag("Mathematics And Sciences"));
-        ModuleCodePredicate secondPredicate = new ModuleCodePredicate(ST2334.getCode().toString(),
-                "4", "Y2S1", "A", tags);
+        ModuleCodePredicate secondPredicate = new ModuleCodePredicate(true, ST2334.getCode().toString(),
+                new HashSet<>(), credits, semYears, grades, tags);
 
         // same object -> returns true
-        assertTrue(firstPredicate.equals(firstPredicate));
-        assertTrue(secondPredicate.equals(secondPredicate));
+        assertEquals(firstPredicate, firstPredicate);
+        assertEquals(secondPredicate, secondPredicate);
 
         // same values -> returns true
-        ModuleCodePredicate firstPredicateCopy = new ModuleCodePredicate(CS1101S.getCode().toString(),
-                "", "", "", new HashSet<>());
-        assertTrue(firstPredicate.equals(firstPredicateCopy));
+        ModuleCodePredicate firstPredicateCopy = new ModuleCodePredicate(true, CS1101S.getCode().toString(),
+                new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>());
+        assertEquals(firstPredicate, firstPredicateCopy);
+
+        HashSet<Credit> creditsCopy = new HashSet<>();
+        creditsCopy.add(new Credit("4"));
+        HashSet<SemYear> semYearsCopy = new HashSet<>();
+        semYearsCopy.add(new SemYear("Y2S1"));
+        HashSet<Grade> gradesCopy = new HashSet<>();
+        gradesCopy.add(new Grade("A"));
         HashSet<Tag> tagsCopy = new HashSet<>();
         tagsCopy.add(new Tag("Mathematics And Sciences"));
-        ModuleCodePredicate secondPredicateCopy = new ModuleCodePredicate(ST2334.getCode().toString(),
-                "4", "Y2S1", "A", tagsCopy);
-        assertTrue(secondPredicate.equals(secondPredicateCopy));
+        ModuleCodePredicate secondPredicateCopy = new ModuleCodePredicate(true, ST2334.getCode().toString(),
+                new HashSet<>(), creditsCopy, semYearsCopy, gradesCopy, tagsCopy);
+        assertEquals(secondPredicate, secondPredicateCopy);
 
         // different types -> returns false
-        assertFalse(firstPredicate.equals(1));
+        assertNotEquals(1, firstPredicate);
 
         // null -> returns false
-        assertFalse(firstPredicate.equals(null));
+        assertNotEquals(null, firstPredicate);
 
         // different person -> returns false
-        assertFalse(firstPredicate.equals(secondPredicate));
+        assertNotEquals(firstPredicate, secondPredicate);
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Non-matching keyword
-        ModuleCodePredicate predicate = new ModuleCodePredicate(CS1101S.getCode().toString(),
-                "", "", "", new HashSet<>());
+        ModuleCodePredicate predicate = new ModuleCodePredicate(true, CS1101S.getCode().toString(),
+                new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>());
         assertFalse(predicate.test(new ModuleBuilder().withCode("ST2334").build()));
     }
 


### PR DESCRIPTION
Users can now do filtering of multiple prefixes when using the find command.

Example 1: `find /m CS /m MA`
Example 2: `find /c 2 /c 4 /y Y2S1`
Example 3: `find /g A+ /g A /g A-`