### PR TITLE
Fix error message for invalid prefixes in edit command arguments

### DIFF
--- a/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
@@ -42,8 +42,6 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
-        Code code = ParserUtil.parseCode(preamble);
-
         EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
 
         boolean isCodePrefixPresent = argMultimap.getValue(PREFIX_CODE).isPresent();
@@ -80,8 +78,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editModuleDescriptor::setTags);
 
         if (!editModuleDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
+
+        Code code = ParserUtil.parseCode(preamble);
 
         return new EditCommand(code, editModuleDescriptor);
     }

--- a/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
@@ -56,7 +56,8 @@ class EditCommandParserTest {
         assertParseFailure(parser, " " + PREFIX_CODE + " " + VALID_CODE_CS1101S, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, " " + VALID_CODE_CS1101S, EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditCommand.MESSAGE_USAGE));
 
         // no module and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -65,10 +66,12 @@ class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, " " + VALID_CODE_CS1101S + VALID_CREDIT_CS1101S, Code.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S + VALID_CREDIT_CS1101S,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, " " + VALID_CODE_CS1101S + "/i " + VALID_CREDIT_CS1101S, Code.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S + "/i " + VALID_CREDIT_CS1101S,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
Fix issues #159 , #147 , #150.
- Parse prefixes before parsing module code to detect invalid prefixes correctly.
- Change error message for missing valid prefixes to invalid command format error message.
