### PR TITLE
Make screen change to module list every time edit command is executed

### DIFF
--- a/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
@@ -66,7 +66,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ObservableList<Module> lastShownList = model.getFilteredModuleList();
+        ObservableList<Module> lastShownList = model.getDegreeProgression().getModuleList();
 
         //should change this to a better way to retrieve module (possibly HashSet for modules?)
         Module moduleToEdit = new Module(code);


### PR DESCRIPTION
Fixes #163 [C], #149 [D]

Although, I'm not sure if you guys want the screen to change every time edit is executed.