### PR TITLE
Allow help command to accept extraneous parameters

### DIFF
--- a/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/HelpCommand.java
@@ -40,9 +40,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        if (selectedMessage.isEmpty()) {
-            return new CommandResult(SHOWING_ALL_MESSAGE_USAGE, false, false, false, false);
-        }
         return new CommandResult(selectedMessage, false, false, false, false);
     }
 

--- a/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.modtrek.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.modtrek.logic.commands.AddCommand;
 import seedu.modtrek.logic.commands.DeleteCommand;

--- a/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
@@ -45,7 +45,7 @@ public class HelpCommandParser implements Parser<HelpCommand> {
         case "SORT":
             return new HelpCommand(SortCommand.MESSAGE_USAGE);
         default:
-            return new HelpCommand("");
+            return new HelpCommand(HelpCommand.SHOWING_ALL_MESSAGE_USAGE);
         }
     }
 }

--- a/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/HelpCommandParser.java
@@ -28,9 +28,6 @@ public class HelpCommandParser implements Parser<HelpCommand> {
         requireNonNull(args);
 
         String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            return new HelpCommand("");
-        }
         switch (trimmedArgs.toUpperCase()) {
         case "ADD":
             return new HelpCommand(AddCommand.MESSAGE_USAGE);
@@ -49,8 +46,7 @@ public class HelpCommandParser implements Parser<HelpCommand> {
         case "SORT":
             return new HelpCommand(SortCommand.MESSAGE_USAGE);
         default:
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            return new HelpCommand("");
         }
     }
 }

--- a/src/main/java/seedu/modtrek/logic/parser/ModTrekParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/ModTrekParser.java
@@ -1,6 +1,5 @@
 package seedu.modtrek.logic.parser;
 
-import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import java.util.regex.Matcher;
@@ -38,7 +37,7 @@ public class ModTrekParser {
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
 
         final String commandWord = matcher.group("commandWord");

--- a/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/modtrek/logic/commands/HelpCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.modtrek.logic.commands;
 
 import static seedu.modtrek.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.modtrek.logic.commands.HelpCommand.SHOWING_ALL_MESSAGE_USAGE;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,9 +13,10 @@ public class HelpCommandTest {
 
     @Test
     public void execute_helpNoArgs_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_ALL_MESSAGE_USAGE,
+        CommandResult expectedCommandResult = new CommandResult(HelpCommand.SHOWING_ALL_MESSAGE_USAGE,
                 false, false, false, false);
-        assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new HelpCommand(HelpCommand.SHOWING_ALL_MESSAGE_USAGE), model,
+                expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
@@ -18,7 +18,7 @@ public class HelpCommandParserTest {
 
     @Test
     public void parse_helpNoArgs_success() {
-        assertParseSuccess(parser, "", new HelpCommand(""));
+        assertParseSuccess(parser, "", new HelpCommand(HelpCommand.SHOWING_ALL_MESSAGE_USAGE));
     }
 
     @Test
@@ -58,6 +58,6 @@ public class HelpCommandParserTest {
 
     @Test
     public void parse_helpInvalidArgs_success() {
-        assertParseSuccess(parser, "wrong", new HelpCommand(""));
+        assertParseSuccess(parser, "wrong", new HelpCommand(HelpCommand.SHOWING_ALL_MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/HelpCommandParserTest.java
@@ -1,7 +1,5 @@
 package seedu.modtrek.logic.parser;
 
-import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.modtrek.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
@@ -59,8 +57,7 @@ public class HelpCommandParserTest {
     }
 
     @Test
-    public void parse_helpInvalidArgs_failure() {
-        assertParseFailure(parser, "wrong",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+    public void parse_helpInvalidArgs_success() {
+        assertParseSuccess(parser, "wrong", new HelpCommand(""));
     }
 }

--- a/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/ModTrekParserTest.java
@@ -2,7 +2,6 @@ package seedu.modtrek.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modtrek.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.modtrek.testutil.Assert.assertThrows;
 import static seedu.modtrek.testutil.TypicalModules.CS1101S;
@@ -87,7 +86,7 @@ public class ModTrekParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
             -> parser.parseCommand(""));
     }
 


### PR DESCRIPTION
Instead of throwing an error when the user types in an incorrect parameter after help (e.g. `help 123` or `help addi`), `help` is simply executed to show the list of help commands. This fix will align with the UG about ignoring extraneous parameters for commands that do not take in parameters.

Will also change the UG portion to reflect only for single-word commands (specifically `exit` and `help`, not `delete all`).

ModTrekParser updated here as well to throw unknown command if empty input (spaces) are executed as command input.