### PR TITLE
Restructure error handling and messages

### DIFF
--- a/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/modtrek/logic/commands/EditCommand.java
@@ -44,7 +44,7 @@ public class EditCommand extends Command {
             + PREFIX_SEMYEAR + " Y2S2";
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. \n\n%1$s";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the grade book.";
 
     private final Code code;

--- a/src/main/java/seedu/modtrek/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/AddCommandParser.java
@@ -36,37 +36,43 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG);
 
-        if (args.isEmpty()) {
+        if (args.isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
+
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CODE, AddCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CREDIT, AddCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_SEMYEAR, AddCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_GRADE, AddCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_TAG, AddCommand.MESSAGE_USAGE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR)) {
             throw new ParseException(AddCommand.MESSAGE_MISSING_PREFIXES);
-        }
-
-        if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         String codeString = argMultimap.getValue(PREFIX_CODE).get();
         if (codeString.isEmpty()) {
             throw new ParseException(Code.MESSAGE_MISSING_DETAIL);
         }
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CODE, AddCommand.MESSAGE_USAGE);
         Code code = ParserUtil.parseCode(codeString);
 
         String creditString = argMultimap.getValue(PREFIX_CREDIT).get();
         if (creditString.isEmpty()) {
             throw new ParseException(Credit.MESSAGE_MISSING_DETAIL);
         }
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CREDIT, AddCommand.MESSAGE_USAGE);
         Credit credit = ParserUtil.parseCredit(creditString);
 
         String semYearString = argMultimap.getValue(PREFIX_SEMYEAR).get();
         if (semYearString.isEmpty()) {
             throw new ParseException(SemYear.MESSAGE_MISSING_DETAIL);
         }
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_SEMYEAR, AddCommand.MESSAGE_USAGE);
         SemYear semYear = ParserUtil.parseSemYear(semYearString);
 
         String gradeString = argMultimap.getValue(PREFIX_GRADE).orElse("");
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_GRADE, AddCommand.MESSAGE_USAGE);
         Grade grade = ParserUtil.parseGrade(gradeString);
 
         boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();

--- a/src/main/java/seedu/modtrek/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/DeleteCommandParser.java
@@ -38,6 +38,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             isAll = true;
             codes = new HashSet<>();
         } else if (flag.isEmpty() && !codeString.isEmpty()) {
+            ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CODE, DeleteCommand.MESSAGE_USAGE);
             isAll = false;
             codes = ParserUtil.parseCodes(argMultimap.getAllValues(PREFIX_CODE));
         } else {

--- a/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/EditCommandParser.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.modtrek.logic.commands.EditCommand;
 import seedu.modtrek.logic.commands.EditCommand.EditModuleDescriptor;
@@ -38,9 +39,21 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG);
 
         String preamble = argMultimap.getPreamble();
-        if (preamble.isEmpty()) {
+        if (preamble.isEmpty() || preamble.contains("/")) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
+
+        Code code = ParserUtil.parseCode(preamble);
+
+        if (!isAnyPrefixPresent(argMultimap, PREFIX_CODE, PREFIX_CREDIT, PREFIX_SEMYEAR, PREFIX_GRADE, PREFIX_TAG)) {
+            throw new ParseException(String.format(EditCommand.MESSAGE_NOT_EDITED, EditCommand.MESSAGE_USAGE));
+        }
+
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CODE, EditCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_CREDIT, EditCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_SEMYEAR, EditCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_GRADE, EditCommand.MESSAGE_USAGE);
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_TAG, EditCommand.MESSAGE_USAGE);
 
         EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
 
@@ -81,9 +94,15 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
-        Code code = ParserUtil.parseCode(preamble);
-
         return new EditCommand(code, editModuleDescriptor);
+    }
+
+    /**
+     * Returns true if any of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean isAnyPrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/seedu/modtrek/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/modtrek/logic/parser/ParserUtil.java
@@ -1,9 +1,11 @@
 package seedu.modtrek.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.modtrek.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -187,5 +189,20 @@ public class ParserUtil {
             codeSet.add(parseCode(code));
         }
         return codeSet;
+    }
+
+    /**
+     * Checks if the argument following the specified prefix contains the "/" character.
+     *
+     * @throws ParseException if the argument following the specified prefix contains the "/" character.
+     */
+    public static void checkIfSlashIsPresent(ArgumentMultimap argumentMultimap, Prefix prefix,
+                                             String messageUsage) throws ParseException {
+        List<String> prefixArgs = argumentMultimap.getAllValues(prefix);
+        for (String prefixArg : prefixArgs) {
+            if (prefixArg.contains("/")) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, messageUsage));
+            }
+        }
     }
 }

--- a/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/modtrek/logic/parser/TagCommandParser.java
@@ -38,6 +38,7 @@ public class TagCommandParser implements Parser<TagCommand> {
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
         }
+        ParserUtil.checkIfSlashIsPresent(argMultimap, PREFIX_TAG, TagCommand.MESSAGE_USAGE);
         Code code = ParserUtil.parseCode(preambleParts[0]);
 
         boolean isTagPresent = argMultimap.getValue(PREFIX_TAG).isPresent();

--- a/src/test/java/seedu/modtrek/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/AddCommandParserTest.java
@@ -112,7 +112,7 @@ public class AddCommandParserTest {
 
         // missing code prefix
         assertParseFailure(parser, VALID_CODE_MA2002 + CREDIT_DESC_MA2002 + SEMYEAR_DESC_MA2002 + GRADE_DESC_MA2002,
-                AddCommand.MESSAGE_MISSING_PREFIXES);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         // missing credit prefix
         assertParseFailure(parser, CODE_DESC_MA2002 + VALID_CREDIT_MA2002 + SEMYEAR_DESC_MA2002 + GRADE_DESC_MA2002,
@@ -124,7 +124,7 @@ public class AddCommandParserTest {
 
         // all prefixes missing
         assertParseFailure(parser, VALID_CODE_MA2002 + VALID_CREDIT_MA2002 + VALID_SEMYEAR_MA2002 + VALID_GRADE_MA2002,
-                AddCommand.MESSAGE_MISSING_PREFIXES);
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/EditCommandParserTest.java
@@ -56,8 +56,8 @@ class EditCommandParserTest {
         assertParseFailure(parser, " " + PREFIX_CODE + " " + VALID_CODE_CS1101S, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, " " + VALID_CODE_CS1101S, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                EditCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " " + VALID_CODE_CS1101S,
+                String.format(EditCommand.MESSAGE_NOT_EDITED, EditCommand.MESSAGE_USAGE));
 
         // no module and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -67,7 +67,7 @@ class EditCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, " " + VALID_CODE_CS1101S + VALID_CREDIT_CS1101S,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+                Code.MESSAGE_CONSTRAINTS);
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, " " + VALID_CODE_CS1101S + "/i " + VALID_CREDIT_CS1101S,

--- a/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
@@ -21,7 +21,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.FindCommand;
-import seedu.modtrek.model.module.*;
+import seedu.modtrek.model.module.Code;
+import seedu.modtrek.model.module.CodePrefix;
+import seedu.modtrek.model.module.Credit;
+import seedu.modtrek.model.module.Grade;
+import seedu.modtrek.model.module.ModuleCodePredicate;
+import seedu.modtrek.model.module.SemYear;
 import seedu.modtrek.model.tag.Tag;
 
 public class FindCommandParserTest {

--- a/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/modtrek/logic/parser/FindCommandParserTest.java
@@ -21,11 +21,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.modtrek.logic.commands.FindCommand;
-import seedu.modtrek.model.module.CodePrefix;
-import seedu.modtrek.model.module.Credit;
-import seedu.modtrek.model.module.Grade;
-import seedu.modtrek.model.module.ModuleCodePredicate;
-import seedu.modtrek.model.module.SemYear;
+import seedu.modtrek.model.module.*;
 import seedu.modtrek.model.tag.Tag;
 
 public class FindCommandParserTest {
@@ -87,8 +83,7 @@ public class FindCommandParserTest {
     @Test
     public void invalidFindByModuleCodeThrowsException() {
         String invalidFindCommandString = " CS";
-        assertParseFailure(parser, invalidFindCommandString, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, invalidFindCommandString, Code.MESSAGE_CONSTRAINTS);
     }
 
     @Test


### PR DESCRIPTION
- Restructured error handling of edge cases for AddCommandParser, EditCommandParser, TagCommandParser, DeleteCommandParser, FindCommandParser classes, since they all take in prefixes with arguments.
- Example: `find /m CS / g A` gives invalid command format. `edit cs333333` gives invalid code.

Help me to run more tests on your side to check if these error messages are working as intended and everything else (correct executions) is working well.